### PR TITLE
add rule which disallow clang-cuda 13 and older

### DIFF
--- a/bashi/filter_compiler_version.py
+++ b/bashi/filter_compiler_version.py
@@ -116,4 +116,17 @@ def compiler_version_filter(
                             return False
                         break
 
+    # Rule: v5
+    # clang-cuda 13 and older is not supported
+    # this rule will be never used, because of an implementation detail of the covertable library
+    # it is not possible to add the clang-cuda versions and filter it out afterwards
+    # this rule is only used by bashi-verify
+    if (
+        DEVICE_COMPILER in row
+        and row[DEVICE_COMPILER].name == CLANG_CUDA
+        and row[DEVICE_COMPILER].version < pkv.parse("14")
+    ):
+        reason(output, "all clang versions older than 14 are disabled as CUDA Compiler")
+        return False
+
     return True

--- a/bashi/generator.py
+++ b/bashi/generator.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, List
 from collections import OrderedDict
+import copy
+import packaging.version as pkv
 
 from covertable import make  # type: ignore
 
@@ -13,6 +15,7 @@ from bashi.types import (
     Combination,
     CombinationList,
 )
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter_chain import get_default_filter_chain
 
 
@@ -31,17 +34,44 @@ def generate_combination_list(
     Returns:
         CombinationList: combination-list
     """
+    # use local version to do not modify parameter_value_matrix
+    local_param_val_mat = copy.deepcopy(parameter_value_matrix)
+
     filter_chain = get_default_filter_chain(custom_filter)
 
-    # TODO(SimeonEhrig): add filter function here, which remove NVCC as host compiler and
-    # CLANG-CUDA 13 and older as compiler
-    # the covertable throws an error, if the filter rule removes to much possibilities in an early
-    # filter
+    def host_compiler_filter(param_val: ParameterValue) -> bool:
+        # Rule: n1
+        # remove nvcc as host compiler
+        if param_val.name == NVCC:
+            return False
+        # Rule: v5
+        # remove clang-cuda older than 14
+        if param_val.name == CLANG_CUDA and param_val.version < pkv.parse("14"):
+            return False
+
+        return True
+
+    def device_compiler_filter(param_val: ParameterValue) -> bool:
+        # Rule: v5
+        # remove clang-cuda older than 14
+        if param_val.name == CLANG_CUDA and param_val.version < pkv.parse("14"):
+            return False
+
+        return True
+
+    pre_filters = {HOST_COMPILER: host_compiler_filter, DEVICE_COMPILER: device_compiler_filter}
+
+    # some filter rules requires that specific parameter-values are already removed from the
+    # parameter-value-matrix
+    # otherwise the covertable library throws an error
+    for param, filter_func in pre_filters.items():
+        if param in local_param_val_mat:
+            local_param_val_mat[param] = list(filter(filter_func, local_param_val_mat[param]))
 
     comb_list: CombinationList = []
 
     all_pairs: List[Dict[Parameter, ParameterValue]] = make(
-        factors=parameter_value_matrix,
+        factors=local_param_val_mat,
         length=2,
         pre_filter=filter_chain,
     )  # type: ignore
@@ -51,7 +81,7 @@ def generate_combination_list(
         tmp_comb: Combination = OrderedDict({})
         # covertable does not keep the ordering of the parameters
         # therefore we sort it
-        for param in parameter_value_matrix.keys():
+        for param in local_param_val_mat.keys():
             tmp_comb[param] = all_pair[param]
         comb_list.append(tmp_comb)
 

--- a/bashi/generator.py
+++ b/bashi/generator.py
@@ -33,6 +33,11 @@ def generate_combination_list(
     """
     filter_chain = get_default_filter_chain(custom_filter)
 
+    # TODO(SimeonEhrig): add filter function here, which remove NVCC as host compiler and
+    # CLANG-CUDA 13 and older as compiler
+    # the covertable throws an error, if the filter rule removes to much possibilities in an early
+    # filter
+
     comb_list: CombinationList = []
 
     all_pairs: List[Dict[Parameter, ParameterValue]] = make(

--- a/bashi/versions.py
+++ b/bashi/versions.py
@@ -1,5 +1,6 @@
 """Provides all supported software versions"""
 
+import copy
 from typing import Dict, List, Union
 from collections import OrderedDict
 from typeguard import typechecked
@@ -121,23 +122,17 @@ def get_parameter_value_matrix() -> ParameterValueMatrix:
     """
     param_val_matrix: ParameterValueMatrix = OrderedDict()
 
-    extended_version = VERSIONS.copy()
+    extended_version = copy.deepcopy(VERSIONS)
     extended_version[CLANG_CUDA] = extended_version[CLANG]
 
     for compiler_type in [HOST_COMPILER, DEVICE_COMPILER]:
         param_val_matrix[compiler_type] = []
         for sw_name, sw_versions in extended_version.items():
-            # do not add NVCC as HOST_COMPILER
-            # filtering out all NVCC as HOST_COMPILER later does not work with the covertable
-            # library
-            if compiler_type == HOST_COMPILER and sw_name == NVCC:
-                continue
             if sw_name in COMPILERS:
                 for sw_version in sw_versions:
-                    if not (sw_name == CLANG_CUDA and pkv.parse(str(sw_version)) < pkv.parse("14")):
-                        param_val_matrix[compiler_type].append(
-                            ParameterValue(sw_name, pkv.parse(str(sw_version)))
-                        )
+                    param_val_matrix[compiler_type].append(
+                        ParameterValue(sw_name, pkv.parse(str(sw_version)))
+                    )
 
     for backend in BACKENDS:
         if backend == ALPAKA_ACC_GPU_CUDA_ENABLE:
@@ -180,7 +175,7 @@ def is_supported_version(name: ValueName, version: ValueVersion) -> bool:
     if name not in known_names:
         raise ValueError(f"Unknown software name: {name}")
 
-    local_versions = VERSIONS.copy()
+    local_versions = copy.deepcopy(VERSIONS)
 
     local_versions[CLANG_CUDA] = local_versions[CLANG]
     local_versions[ALPAKA_ACC_GPU_CUDA_ENABLE] = [OFF]

--- a/bashi/versions.py
+++ b/bashi/versions.py
@@ -111,6 +111,7 @@ NVCC_CLANG_MAX_VERSION: List[NvccHostSupport] = [
 NVCC_CLANG_MAX_VERSION.sort(reverse=True)
 
 
+# pylint: disable=too-many-branches
 def get_parameter_value_matrix() -> ParameterValueMatrix:
     """Generates a parameter-value-matrix from all supported compilers, softwares and compilation
     configuration.
@@ -133,9 +134,10 @@ def get_parameter_value_matrix() -> ParameterValueMatrix:
                 continue
             if sw_name in COMPILERS:
                 for sw_version in sw_versions:
-                    param_val_matrix[compiler_type].append(
-                        ParameterValue(sw_name, pkv.parse(str(sw_version)))
-                    )
+                    if not (sw_name == CLANG_CUDA and pkv.parse(str(sw_version)) < pkv.parse("14")):
+                        param_val_matrix[compiler_type].append(
+                            ParameterValue(sw_name, pkv.parse(str(sw_version)))
+                        )
 
     for backend in BACKENDS:
         if backend == ALPAKA_ACC_GPU_CUDA_ENABLE:

--- a/tests/test_clang_cuda_filter.py
+++ b/tests/test_clang_cuda_filter.py
@@ -1,0 +1,78 @@
+# pylint: disable=missing-docstring
+import unittest
+import io
+
+from collections import OrderedDict as OD
+from utils_test import parse_param_val as ppv
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.filter_compiler_version import compiler_version_filter_typechecked
+
+
+class TestClangCudaOldVersions(unittest.TestCase):
+    def test_valid_clang_cuda_versions_rule_v5(self):
+        for clang_cuda_version in [14, 16, 18, 78]:
+            self.assertTrue(
+                compiler_version_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                            DEVICE_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                        }
+                    )
+                )
+            )
+
+    def test_valid_clang_cuda_versions_multi_row_rule_v5(self):
+        for clang_cuda_version in [14, 16, 18, 78]:
+            self.assertTrue(
+                compiler_version_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+                            DEVICE_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                            CMAKE: ppv((CMAKE, 3.22)),
+                        }
+                    ),
+                )
+            )
+
+    def test_invalid_clang_cuda_versions_rule_v5(self):
+        for clang_cuda_version in [13, 7, 1]:
+            reason_msg = io.StringIO()
+            self.assertFalse(
+                compiler_version_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                            DEVICE_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                        }
+                    ),
+                    reason_msg,
+                )
+            )
+            self.assertEqual(
+                reason_msg.getvalue(),
+                "all clang versions older than 14 are disabled as CUDA Compiler",
+            )
+
+    def test_invalid_clang_cuda_versions_multi_row_rule_v5(self):
+        for clang_cuda_version in [13, 7, 1]:
+            reason_msg = io.StringIO()
+            self.assertFalse(
+                compiler_version_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+                            DEVICE_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
+                            CMAKE: ppv((CMAKE, 3.22)),
+                        }
+                    ),
+                    reason_msg,
+                )
+            )
+            self.assertEqual(
+                reason_msg.getvalue(),
+                "all clang versions older than 14 are disabled as CUDA Compiler",
+            )

--- a/tests/test_expected_parameter_value_pairs.py
+++ b/tests/test_expected_parameter_value_pairs.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 import unittest
+import copy
 from typing import List, Dict
 from collections import OrderedDict
 import io
@@ -635,7 +636,7 @@ class TestRemoveExpectedParameterValuePair(unittest.TestCase):
 
         expected_number_of_reduced_pairs = len(reduced_param_value_pairs)
 
-        expected_reduced_param_value_pairs = reduced_param_value_pairs.copy()
+        expected_reduced_param_value_pairs = copy.deepcopy(reduced_param_value_pairs)
 
         # remove single value to verify that default flag is working
         example_single_pair = create_parameter_value_pair(

--- a/tests/test_filter_compiler_version.py
+++ b/tests/test_filter_compiler_version.py
@@ -33,9 +33,9 @@ class TestHostDeviceCompilerSameVersion(unittest.TestCase):
             compiler_version_filter_typechecked(
                 OD(
                     {
-                        HOST_COMPILER: ppv((CLANG_CUDA, 10)),
+                        HOST_COMPILER: ppv((CLANG_CUDA, 14)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
-                        DEVICE_COMPILER: ppv((CLANG_CUDA, 10)),
+                        DEVICE_COMPILER: ppv((CLANG_CUDA, 14)),
                         CMAKE: ppv((CMAKE, 3.18)),
                     }
                 )

--- a/tests/test_params_value_matrix_generator.py
+++ b/tests/test_params_value_matrix_generator.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 import unittest
+import packaging.version as pkv
 from bashi.versions import VERSIONS, get_parameter_value_matrix
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
@@ -25,7 +26,15 @@ class TestParameterValueGenerator(unittest.TestCase):
 
     def test_number_host_device_compiler(self):
         extended_versions = VERSIONS.copy()
-        extended_versions[CLANG_CUDA] = extended_versions[CLANG]
+        # filter clang-cuda 13 and older because the pair-wise generator cannot filter it out
+        # afterwards
+        extended_versions[CLANG_CUDA] = list(
+            filter(
+                lambda clang_version: pkv.parse(str(clang_version)) >= pkv.parse("14"),
+                extended_versions[CLANG],
+            )
+        )
+
         number_of_host_compilers = 0
         for compiler in COMPILERS:
             if compiler != NVCC:

--- a/tests/test_params_value_matrix_generator.py
+++ b/tests/test_params_value_matrix_generator.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring
 import unittest
-import packaging.version as pkv
+import copy
 from bashi.versions import VERSIONS, get_parameter_value_matrix
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
@@ -25,23 +25,17 @@ class TestParameterValueGenerator(unittest.TestCase):
         )
 
     def test_number_host_device_compiler(self):
-        extended_versions = VERSIONS.copy()
+        extended_versions = copy.deepcopy(VERSIONS)
         # filter clang-cuda 13 and older because the pair-wise generator cannot filter it out
         # afterwards
-        extended_versions[CLANG_CUDA] = list(
-            filter(
-                lambda clang_version: pkv.parse(str(clang_version)) >= pkv.parse("14"),
-                extended_versions[CLANG],
-            )
-        )
+        extended_versions[CLANG_CUDA] = extended_versions[CLANG]
 
         number_of_host_compilers = 0
         for compiler in COMPILERS:
-            if compiler != NVCC:
-                number_of_host_compilers += len(extended_versions[compiler])
+            number_of_host_compilers += len(extended_versions[compiler])
 
         # NVCC is only as device compiler added
-        number_of_device_compilers = number_of_host_compilers + len(extended_versions[NVCC])
+        number_of_device_compilers = number_of_host_compilers
 
         self.assertEqual(len(self.param_val_matrix[HOST_COMPILER]), number_of_host_compilers)
         self.assertEqual(len(self.param_val_matrix[DEVICE_COMPILER]), number_of_device_compilers)


### PR DESCRIPTION
The PR also solves a problem, that `generate_combination_list()` disallow specific parameter-values, like nvcc as host compiler.