### PR TITLE
add different rules, which handles alpaka backends with different compilers

### DIFF
--- a/bashi/filter_backend.py
+++ b/bashi/filter_backend.py
@@ -49,4 +49,10 @@ def backend_filter(
                 reason(output, "An enabled HIP backend requires hipcc as compiler.")
                 return False
 
+        # Rule: b2
+        # related to rule c10
+        if ALPAKA_ACC_SYCL_ENABLE in row and row[ALPAKA_ACC_SYCL_ENABLE].version != OFF_VER:
+            reason(output, "The HIP and SYCL backend cannot be enabled on the same time.")
+            return False
+
     return True

--- a/bashi/filter_backend.py
+++ b/bashi/filter_backend.py
@@ -55,4 +55,10 @@ def backend_filter(
             reason(output, "The HIP and SYCL backend cannot be enabled on the same time.")
             return False
 
+        # Rule: b3
+        # related to rule c11
+        if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
+            reason(output, "The HIP and CUDA backend cannot be enabled on the same time.")
+            return False
+
     return True

--- a/bashi/filter_backend.py
+++ b/bashi/filter_backend.py
@@ -8,9 +8,12 @@ which rule.
 """
 
 from typing import Optional, IO
+import packaging.version as pkv
 from typeguard import typechecked
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.types import ParameterValueTuple
+from bashi.versions import NVCC_GCC_MAX_VERSION, NVCC_CLANG_MAX_VERSION
+
 from bashi.utils import reason
 
 
@@ -27,6 +30,7 @@ def backend_filter_typechecked(
 
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-return-statements
+# pylint: disable=too-many-nested-blocks
 def backend_filter(
     row: ParameterValueTuple,
     output: Optional[IO[str]] = None,
@@ -81,6 +85,99 @@ def backend_filter(
         # related to rule c14
         if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
             reason(output, "The SYCL and CUDA backend cannot be enabled on the same time.")
+            return False
+
+    if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == OFF_VER:
+        # Rule: b7
+        if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
+            reason(output, "CUDA backend needs to be enabled for nvcc")
+            return False
+
+    if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
+        # Rule: b8
+        # related to rule c2
+        if HOST_COMPILER in row and row[HOST_COMPILER].name in (
+            set(COMPILERS) - set([GCC, CLANG, NVCC, CLANG_CUDA])
+        ):
+            reason(
+                output, f"host-compiler {row[HOST_COMPILER].name} does not support the CUDA backend"
+            )
+            return False
+
+        # Rule: b9
+        # related to rule c15
+        if (
+            DEVICE_COMPILER in row
+            and row[DEVICE_COMPILER].name == NVCC
+            and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != row[DEVICE_COMPILER].version
+        ):
+            reason(output, "CUDA backend and nvcc needs to have the same version")
+            return False
+
+        if HOST_COMPILER in row and row[HOST_COMPILER].name == GCC:
+            # Rule: b10
+            # related to rule c5
+            # remove all unsupported cuda sdk gcc version combinations
+            # define which is the latest supported gcc compiler for a cuda sdk version
+
+            # if a cuda sdk version is not supported by bashi, assume that the version supports the
+            # latest gcc compiler version
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version <= NVCC_GCC_MAX_VERSION[0].nvcc:
+                # check the maximum supported gcc version for the given nvcc version
+                for nvcc_gcc_comb in NVCC_GCC_MAX_VERSION:
+                    if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version >= nvcc_gcc_comb.nvcc:
+                        if row[HOST_COMPILER].version > nvcc_gcc_comb.host:
+                            reason(
+                                output,
+                                f"CUDA {row[ALPAKA_ACC_GPU_CUDA_ENABLE].version} "
+                                f"does not support gcc {row[HOST_COMPILER].version}",
+                            )
+                            return False
+                        break
+
+        if HOST_COMPILER in row and row[HOST_COMPILER].name == CLANG:
+            # Rule: b11
+            # related to rule c8
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version >= pkv.parse("11.3") and row[
+                ALPAKA_ACC_GPU_CUDA_ENABLE
+            ].version <= pkv.parse("11.5"):
+                reason(
+                    output,
+                    "clang as host compiler is disabled for CUDA 11.3 to 11.5",
+                )
+                return False
+
+            # Rule: b12
+            # related to rule c6
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version <= NVCC_CLANG_MAX_VERSION[0].nvcc:
+                # check the maximum supported clang version for the given cuda sdk version
+                for nvcc_clang_comb in NVCC_CLANG_MAX_VERSION:
+                    if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version >= nvcc_clang_comb.nvcc:
+                        if row[HOST_COMPILER].version > nvcc_clang_comb.host:
+                            reason(
+                                output,
+                                f"CUDA {row[ALPAKA_ACC_GPU_CUDA_ENABLE].version} "
+                                f"does not support clang {row[HOST_COMPILER].version}",
+                            )
+                            return False
+                        break
+
+        # Rule: b13
+        # related to rule c2
+        if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name not in (NVCC, CLANG_CUDA):
+            reason(output, f"{row[DEVICE_COMPILER].name} does not support the CUDA backend")
+            return False
+
+        # Rule: b14
+        # related to rule c16
+        if ALPAKA_ACC_GPU_HIP_ENABLE in row and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
+            reason(output, "The CUDA and HIP backend cannot be enabled on the same time.")
+            return False
+
+        # Rule: b15
+        # related to rule c17
+        if ALPAKA_ACC_SYCL_ENABLE in row and row[ALPAKA_ACC_SYCL_ENABLE].version != OFF_VER:
+            reason(output, "The CUDA and SYCL backend cannot be enabled on the same time.")
             return False
 
     return True

--- a/bashi/filter_backend.py
+++ b/bashi/filter_backend.py
@@ -25,6 +25,8 @@ def backend_filter_typechecked(
     return backend_filter(row, output)
 
 
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-return-statements
 def backend_filter(
     row: ParameterValueTuple,
     output: Optional[IO[str]] = None,
@@ -59,6 +61,26 @@ def backend_filter(
         # related to rule c11
         if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
             reason(output, "The HIP and CUDA backend cannot be enabled on the same time.")
+            return False
+
+    if ALPAKA_ACC_SYCL_ENABLE in row and row[ALPAKA_ACC_SYCL_ENABLE].version != OFF_VER:
+        # Rule: b4
+        # related to rule c12
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            if compiler_type in row and row[compiler_type].name != ICPX:
+                reason(output, "An enabled SYCL backend requires icpx as compiler.")
+                return False
+
+        # Rule: b5
+        # related to rule c13
+        if ALPAKA_ACC_GPU_HIP_ENABLE in row and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
+            reason(output, "The SYCL and HIP backend cannot be enabled on the same time.")
+            return False
+
+        # Rule: b6
+        # related to rule c14
+        if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
+            reason(output, "The SYCL and CUDA backend cannot be enabled on the same time.")
             return False
 
     return True

--- a/bashi/filter_compiler.py
+++ b/bashi/filter_compiler.py
@@ -172,4 +172,29 @@ def compiler_filter(
                 reason(output, "hipcc does not support the CUDA backend.")
                 return False
 
+        if compiler in row and row[compiler].name == ICPX:
+            # Rule: c12
+            # related to rule b4
+            if ALPAKA_ACC_SYCL_ENABLE in row and row[ALPAKA_ACC_SYCL_ENABLE].version == OFF_VER:
+                reason(output, "icpx requires an enabled SYCL backend.")
+                return False
+
+            # Rule: c13
+            # related to rule b5
+            if (
+                ALPAKA_ACC_GPU_HIP_ENABLE in row
+                and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER
+            ):
+                reason(output, "icpx does not support the HIP backend.")
+                return False
+
+            # Rule: c14
+            # related to rule b6
+            if (
+                ALPAKA_ACC_GPU_CUDA_ENABLE in row
+                and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
+            ):
+                reason(output, "icpx does not support the CUDA backend.")
+                return False
+
     return True

--- a/bashi/filter_compiler.py
+++ b/bashi/filter_compiler.py
@@ -48,7 +48,7 @@ def compiler_filter(
         bool: True, if parameter-value-tuple is valid.
     """
     # uncomment me for debugging
-    # print_row_nice(row)
+    # print_row_nice(row, bashi_validate=False)
 
     # Rule: c1
     # NVCC as HOST_COMPILER is not allow

--- a/bashi/filter_compiler.py
+++ b/bashi/filter_compiler.py
@@ -146,4 +146,15 @@ def compiler_filter(
             reason(output, "all clang versions older than 14 are disabled as CUDA Compiler")
             return False
 
+    for compiler in (HOST_COMPILER, DEVICE_COMPILER):
+        if compiler in row and row[compiler].name == HIPCC:
+            # Rule: c9
+            # related to rule b1
+            if (
+                ALPAKA_ACC_GPU_HIP_ENABLE in row
+                and row[ALPAKA_ACC_GPU_HIP_ENABLE].version == OFF_VER
+            ):
+                reason(output, "hipcc requires an enabled HIP backend.")
+                return False
+
     return True

--- a/bashi/filter_compiler.py
+++ b/bashi/filter_compiler.py
@@ -157,4 +157,10 @@ def compiler_filter(
                 reason(output, "hipcc requires an enabled HIP backend.")
                 return False
 
+            # Rule: c10
+            # related to rule b2
+            if ALPAKA_ACC_SYCL_ENABLE in row and row[ALPAKA_ACC_SYCL_ENABLE].version != OFF_VER:
+                reason(output, "hipcc does not support the SYCL backend.")
+                return False
+
     return True

--- a/bashi/filter_compiler.py
+++ b/bashi/filter_compiler.py
@@ -62,6 +62,7 @@ def compiler_filter(
     if HOST_COMPILER in row and DEVICE_COMPILER in row:
         if NVCC in (row[HOST_COMPILER].name, row[DEVICE_COMPILER].name):
             # Rule: c2
+            # related to rule c13
             if row[HOST_COMPILER].name not in (GCC, CLANG):
                 reason(output, "only gcc and clang are allowed as nvcc host compiler")
                 return False
@@ -84,6 +85,7 @@ def compiler_filter(
     if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
         if HOST_COMPILER in row and row[HOST_COMPILER].name == GCC:
             # Rule: c5
+            # related to rule b10
             # remove all unsupported nvcc gcc version combinations
             # define which is the latest supported gcc compiler for a nvcc version
 
@@ -104,6 +106,7 @@ def compiler_filter(
 
         if HOST_COMPILER in row and row[HOST_COMPILER].name == CLANG:
             # Rule: c7
+            # related to rule b11
             if row[DEVICE_COMPILER].version >= pkv.parse("11.3") and row[
                 DEVICE_COMPILER
             ].version <= pkv.parse("11.5"):
@@ -114,6 +117,7 @@ def compiler_filter(
                 return False
 
             # Rule: c6
+            # related to rule b12
             # remove all unsupported nvcc clang version combinations
             # define which is the latest supported clang compiler for a nvcc version
 
@@ -132,7 +136,29 @@ def compiler_filter(
                             return False
                         break
 
+        # Rule: c15
+        # related to rule b9
+        if (
+            ALPAKA_ACC_GPU_CUDA_ENABLE in row
+            and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != row[DEVICE_COMPILER].version
+        ):
+            reason(output, "nvcc and CUDA backend needs to have the same version")
+            return False
+
+        # Rule: c16
+        # related to rule b14
+        if ALPAKA_ACC_GPU_HIP_ENABLE in row and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
+            reason(output, "nvcc does not support the HIP backend.")
+            return False
+
+        # Rule: c17
+        # related to rule b15
+        if ALPAKA_ACC_SYCL_ENABLE in row and row[ALPAKA_ACC_SYCL_ENABLE].version != OFF_VER:
+            reason(output, "nvcc does not support the SYCL backend.")
+            return False
+
     # Rule: c8
+    # related to rule b11
     # clang-cuda 13 and older is not supported
     # this rule will be never used, because of an implementation detail of the covertable library
     # it is not possible to add the clang-cuda versions and filter it out afterwards

--- a/bashi/filter_compiler.py
+++ b/bashi/filter_compiler.py
@@ -163,4 +163,13 @@ def compiler_filter(
                 reason(output, "hipcc does not support the SYCL backend.")
                 return False
 
+            # Rule: c11
+            # related to rule b2
+            if (
+                ALPAKA_ACC_GPU_CUDA_ENABLE in row
+                and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
+            ):
+                reason(output, "hipcc does not support the CUDA backend.")
+                return False
+
     return True

--- a/bashi/results.py
+++ b/bashi/results.py
@@ -78,6 +78,8 @@ def get_expected_bashi_parameter_value_pairs(
         value_name2=ALPAKA_ACC_SYCL_ENABLE,
         value_version2=ON,
     )
+    _remove_enabled_cuda_backend_for_hipcc(param_val_pair_list)
+    _remove_enabled_cuda_backend_for_enabled_hip_backend(param_val_pair_list)
 
     return param_val_pair_list
 
@@ -321,3 +323,40 @@ def _remove_enabled_sycl_backend_for_hipcc(parameter_value_pairs: List[Parameter
             value_name2=ALPAKA_ACC_SYCL_ENABLE,
             value_version2=ON,
         )
+
+
+def _remove_enabled_cuda_backend_for_hipcc(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hipcc is the compiler and the sycl backend is enabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        remove_parameter_value_pairs(
+            parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=HIPCC,
+            value_version1=ANY_VERSION,
+            parameter2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+            value_name2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+            value_version2="==0.0.0",
+        )
+
+
+def _remove_enabled_cuda_backend_for_enabled_hip_backend(
+    parameter_value_pairs: List[ParameterValuePair],
+):
+    """Remove all pairs, where the hipcc is the compiler and the sycl backend is enabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    remove_parameter_value_pairs(
+        parameter_value_pairs,
+        parameter1=ALPAKA_ACC_GPU_HIP_ENABLE,
+        value_name1=ALPAKA_ACC_GPU_HIP_ENABLE,
+        value_version1=ON,
+        parameter2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+        value_name2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+        value_version2="==0.0.0",
+    )

--- a/bashi/results.py
+++ b/bashi/results.py
@@ -80,6 +80,11 @@ def get_expected_bashi_parameter_value_pairs(
     )
     _remove_enabled_cuda_backend_for_hipcc(param_val_pair_list)
     _remove_enabled_cuda_backend_for_enabled_hip_backend(param_val_pair_list)
+    _remove_unsupported_compiler_for_sycl_backend(param_val_pair_list)
+    _remove_disabled_sycl_backend_for_icpx(param_val_pair_list)
+    _remove_enabled_hip_backend_for_icpx(param_val_pair_list)
+    _remove_enabled_cuda_backend_for_icpx(param_val_pair_list)
+    _remove_enabled_cuda_backend_for_enabled_sycl_backend(param_val_pair_list)
 
     return param_val_pair_list
 
@@ -355,6 +360,99 @@ def _remove_enabled_cuda_backend_for_enabled_hip_backend(
         parameter_value_pairs,
         parameter1=ALPAKA_ACC_GPU_HIP_ENABLE,
         value_name1=ALPAKA_ACC_GPU_HIP_ENABLE,
+        value_version1=ON,
+        parameter2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+        value_name2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+        value_version2="==0.0.0",
+    )
+
+
+def _remove_unsupported_compiler_for_sycl_backend(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hip backend is enabled and the compiler is not hipcc.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_name in COMPILERS:
+        if compiler_name != ICPX:
+            for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+                remove_parameter_value_pairs(
+                    parameter_value_pairs,
+                    parameter1=compiler_type,
+                    value_name1=compiler_name,
+                    value_version1=ANY_VERSION,
+                    parameter2=ALPAKA_ACC_SYCL_ENABLE,
+                    value_name2=ALPAKA_ACC_SYCL_ENABLE,
+                    value_version2=ON,
+                )
+
+
+def _remove_disabled_sycl_backend_for_icpx(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hipcc is the compiler and the hip backend is disabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        remove_parameter_value_pairs(
+            parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=ICPX,
+            value_version1=ANY_VERSION,
+            parameter2=ALPAKA_ACC_SYCL_ENABLE,
+            value_name2=ALPAKA_ACC_SYCL_ENABLE,
+            value_version2=OFF,
+        )
+
+
+def _remove_enabled_hip_backend_for_icpx(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hipcc is the compiler and the sycl backend is enabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        remove_parameter_value_pairs(
+            parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=ICPX,
+            value_version1=ANY_VERSION,
+            parameter2=ALPAKA_ACC_GPU_HIP_ENABLE,
+            value_name2=ALPAKA_ACC_GPU_HIP_ENABLE,
+            value_version2=ON,
+        )
+
+
+def _remove_enabled_cuda_backend_for_icpx(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hipcc is the compiler and the sycl backend is enabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        remove_parameter_value_pairs(
+            parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=ICPX,
+            value_version1=ANY_VERSION,
+            parameter2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+            value_name2=ALPAKA_ACC_GPU_CUDA_ENABLE,
+            value_version2="==0.0.0",
+        )
+
+
+def _remove_enabled_cuda_backend_for_enabled_sycl_backend(
+    parameter_value_pairs: List[ParameterValuePair],
+):
+    """Remove all pairs, where the hipcc is the compiler and the sycl backend is enabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    remove_parameter_value_pairs(
+        parameter_value_pairs,
+        parameter1=ALPAKA_ACC_SYCL_ENABLE,
+        value_name1=ALPAKA_ACC_SYCL_ENABLE,
         value_version1=ON,
         parameter2=ALPAKA_ACC_GPU_CUDA_ENABLE,
         value_name2=ALPAKA_ACC_GPU_CUDA_ENABLE,

--- a/bashi/results.py
+++ b/bashi/results.py
@@ -66,6 +66,8 @@ def get_expected_bashi_parameter_value_pairs(
     _remove_nvcc_unsupported_gcc_versions(param_val_pair_list)
     _remove_nvcc_unsupported_clang_versions(param_val_pair_list)
     _remove_specific_nvcc_clang_combinations(param_val_pair_list)
+    _remove_unsupported_compiler_for_hip_backend(param_val_pair_list)
+    _remove_disabled_hip_backend_for_hipcc(param_val_pair_list)
 
     return param_val_pair_list
 
@@ -253,3 +255,41 @@ def _remove_specific_nvcc_clang_combinations(parameter_value_pairs: List[Paramet
         value_name2=NVCC,
         value_version2="!=11.3,!=11.4,!=11.5",
     )
+
+
+def _remove_unsupported_compiler_for_hip_backend(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hip backend is enabled and the compiler is not hipcc.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_name in COMPILERS:
+        if compiler_name != HIPCC:
+            for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+                remove_parameter_value_pairs(
+                    parameter_value_pairs,
+                    parameter1=compiler_type,
+                    value_name1=compiler_name,
+                    value_version1=ANY_VERSION,
+                    parameter2=ALPAKA_ACC_GPU_HIP_ENABLE,
+                    value_name2=ALPAKA_ACC_GPU_HIP_ENABLE,
+                    value_version2=ON,
+                )
+
+
+def _remove_disabled_hip_backend_for_hipcc(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hipcc is the compiler and the hip backend is disabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        remove_parameter_value_pairs(
+            parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=HIPCC,
+            value_version1=ANY_VERSION,
+            parameter2=ALPAKA_ACC_GPU_HIP_ENABLE,
+            value_name2=ALPAKA_ACC_GPU_HIP_ENABLE,
+            value_version2=OFF,
+        )

--- a/bashi/results.py
+++ b/bashi/results.py
@@ -68,6 +68,16 @@ def get_expected_bashi_parameter_value_pairs(
     _remove_specific_nvcc_clang_combinations(param_val_pair_list)
     _remove_unsupported_compiler_for_hip_backend(param_val_pair_list)
     _remove_disabled_hip_backend_for_hipcc(param_val_pair_list)
+    _remove_enabled_sycl_backend_for_hipcc(param_val_pair_list)
+    remove_parameter_value_pairs(
+        param_val_pair_list,
+        parameter1=ALPAKA_ACC_GPU_HIP_ENABLE,
+        value_name1=ALPAKA_ACC_GPU_HIP_ENABLE,
+        value_version1=ON,
+        parameter2=ALPAKA_ACC_SYCL_ENABLE,
+        value_name2=ALPAKA_ACC_SYCL_ENABLE,
+        value_version2=ON,
+    )
 
     return param_val_pair_list
 
@@ -292,4 +302,22 @@ def _remove_disabled_hip_backend_for_hipcc(parameter_value_pairs: List[Parameter
             parameter2=ALPAKA_ACC_GPU_HIP_ENABLE,
             value_name2=ALPAKA_ACC_GPU_HIP_ENABLE,
             value_version2=OFF,
+        )
+
+
+def _remove_enabled_sycl_backend_for_hipcc(parameter_value_pairs: List[ParameterValuePair]):
+    """Remove all pairs, where the hipcc is the compiler and the sycl backend is enabled.
+
+    Args:
+        parameter_value_pairs (List[ParameterValuePair]): parameter-value-pair list
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        remove_parameter_value_pairs(
+            parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=HIPCC,
+            value_version1=ANY_VERSION,
+            parameter2=ALPAKA_ACC_SYCL_ENABLE,
+            value_name2=ALPAKA_ACC_SYCL_ENABLE,
+            value_version2=ON,
         )

--- a/bashi/utils.py
+++ b/bashi/utils.py
@@ -22,6 +22,21 @@ from bashi.types import (
 )
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
+# short names for parameter
+PARAMETER_SHORT_NAME: dict[Parameter, str] = {
+    HOST_COMPILER: "host",
+    DEVICE_COMPILER: "device",
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "bOpenMP2thread",
+    ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "bOpenMP2block",
+    ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: "bSeq",
+    ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "bThreads",
+    ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: "bTBB",
+    ALPAKA_ACC_GPU_CUDA_ENABLE: "bCUDA",
+    ALPAKA_ACC_GPU_HIP_ENABLE: "bHIP",
+    ALPAKA_ACC_SYCL_ENABLE: "bSYCL",
+    CXX_STANDARD: "c++",
+}
+
 
 @dataclasses.dataclass
 class FilterAdapter:
@@ -371,40 +386,35 @@ def reason(output: Optional[IO[str]], msg: str):
 
 
 # do not cover code, because the function is only used for debugging
-def print_row_nice(row: ParameterValueTuple, init: str = ""):  # pragma: no cover
+def print_row_nice(
+    row: ParameterValueTuple, init: str = "", bashi_validate: bool = False
+):  # pragma: no cover
     """Prints a parameter-value-tuple in a short and nice way.
 
     Args:
         row (ParameterValueTuple): row with parameter-value-tuple
         init (str, optional): Prefix of the output string. Defaults to "".
+        bashi_validate (bool): If it is set to True, the row is printed in a form that can be passed
+            directly as arguments to bashi-validate. Defaults to False.
     """
     s = init
-    short_name: dict[str, str] = {
-        HOST_COMPILER: "host",
-        DEVICE_COMPILER: "device",
-        ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "bOpenMP2thread",
-        ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "bOpenMP2block",
-        ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: "bSeq",
-        ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "bThreads",
-        ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: "bTBB",
-        ALPAKA_ACC_GPU_CUDA_ENABLE: "bCUDA",
-        ALPAKA_ACC_GPU_HIP_ENABLE: "bHIP",
-        ALPAKA_ACC_SYCL_ENABLE: "bSYCL",
-        CXX_STANDARD: "c++",
-    }
+
     nice_version: dict[packaging.version.Version, str] = {
         ON_VER: "ON",
         OFF_VER: "OFF",
     }
 
     for param, val in row.items():
+        parameter_prefix = "" if not bashi_validate else "--"
         if param in [HOST_COMPILER, DEVICE_COMPILER]:
             s += (
-                f"{short_name.get(param, param)}={short_name.get(val.name, val.name)}-"
+                f"{parameter_prefix}{PARAMETER_SHORT_NAME.get(param, param)}="
+                f"{PARAMETER_SHORT_NAME.get(val.name, val.name)}@"
                 f"{nice_version.get(val.version, str(val.version))} "
             )
         else:
             s += (
-                f"{short_name.get(param, param)}={nice_version.get(val.version, str(val.version))} "
+                f"{parameter_prefix}{PARAMETER_SHORT_NAME.get(param, param)}="
+                f"{nice_version.get(val.version, str(val.version))} "
             )
     print(s)

--- a/example/example.py
+++ b/example/example.py
@@ -18,7 +18,8 @@ import sys
 from bashi.generator import generate_combination_list
 from bashi.utils import (
     check_parameter_value_pair_in_combination_list,
-    remove_parameter_value_pairs,
+    # TODO(SimeonEhrig): bring me back, if all GPU backend filter rules was implemented
+    # remove_parameter_value_pairs,
 )
 from bashi.results import get_expected_bashi_parameter_value_pairs
 from bashi.types import (
@@ -28,7 +29,11 @@ from bashi.types import (
     CombinationList,
 )
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from bashi.versions import get_parameter_value_matrix, VERSIONS
+from bashi.versions import (
+    get_parameter_value_matrix,
+    # TODO(SimeonEhrig): bring me back, if all GPU backend filter rules was implemented
+    # VERSIONS,
+)
 
 
 # pylint: disable=too-many-branches
@@ -103,7 +108,8 @@ def verify(combination_list: CombinationList, param_value_matrix: ParameterValue
     )
 
 
-def custom_filter(row: ParameterValueTuple) -> bool:
+# TODO(SimeonEhrig): remove pylint statement
+def custom_filter(row: ParameterValueTuple) -> bool:  # pylint: disable=unused-argument
     """Filter function defined by the user. In this case, remove some backend combinations, see
     module documentation.
 

--- a/example/example.py
+++ b/example/example.py
@@ -47,55 +47,56 @@ def verify(combination_list: CombinationList, param_value_matrix: ParameterValue
         param_value_matrix
     )
 
-    gpu_backends = set(
-        [
-            ALPAKA_ACC_GPU_CUDA_ENABLE,
-            ALPAKA_ACC_GPU_HIP_ENABLE,
-            ALPAKA_ACC_SYCL_ENABLE,
-        ]
-    )
+    # TODO(SimeonEhrig): bring me back, if all GPU backend filter rules was implemented
+    # gpu_backends = set(
+    #     [
+    #         ALPAKA_ACC_GPU_CUDA_ENABLE,
+    #         ALPAKA_ACC_GPU_HIP_ENABLE,
+    #         ALPAKA_ACC_SYCL_ENABLE,
+    #     ]
+    # )
 
-    # if one of the GPU backend is enabled, all other backends needs to be disabled
-    # special case CUDA backend: instead it has the version on or off, it has off or a version
-    # number
-    for gpu_backend in gpu_backends:
-        if gpu_backend == ALPAKA_ACC_GPU_CUDA_ENABLE:
-            gpu_versions = VERSIONS[NVCC]
-        else:
-            gpu_versions = [ON]
-        for gpu_version in gpu_versions:
-            for other_backend in set(BACKENDS) - set([gpu_backend]):
-                if other_backend == ALPAKA_ACC_GPU_CUDA_ENABLE:
-                    other_backend_versions = VERSIONS[NVCC]
-                else:
-                    other_backend_versions = [ON]
+    # # if one of the GPU backend is enabled, all other backends needs to be disabled
+    # # special case CUDA backend: instead it has the version on or off, it has off or a version
+    # # number
+    # for gpu_backend in gpu_backends:
+    #     if gpu_backend == ALPAKA_ACC_GPU_CUDA_ENABLE:
+    #         gpu_versions = VERSIONS[NVCC]
+    #     else:
+    #         gpu_versions = [ON]
+    #     for gpu_version in gpu_versions:
+    #         for other_backend in set(BACKENDS) - set([gpu_backend]):
+    #             if other_backend == ALPAKA_ACC_GPU_CUDA_ENABLE:
+    #                 other_backend_versions = VERSIONS[NVCC]
+    #             else:
+    #                 other_backend_versions = [ON]
 
-                for other_backend_version in other_backend_versions:
-                    remove_parameter_value_pairs(
-                        expected_param_val_tuple,
-                        parameter1=gpu_backend,
-                        value_name1=gpu_backend,
-                        value_version1=gpu_version,
-                        parameter2=other_backend,
-                        value_name2=other_backend,
-                        value_version2=other_backend_version,
-                    )
+    #             for other_backend_version in other_backend_versions:
+    #                 remove_parameter_value_pairs(
+    #                     expected_param_val_tuple,
+    #                     parameter1=gpu_backend,
+    #                     value_name1=gpu_backend,
+    #                     value_version1=gpu_version,
+    #                     parameter2=other_backend,
+    #                     value_name2=other_backend,
+    #                     value_version2=other_backend_version,
+    #                 )
 
-    cpu_backends = set(BACKENDS) - gpu_backends
-    # remove all pairs, which contains two cpu backends and on of the backends is enabled and the
-    # other is disabled
-    for cpu_backend in cpu_backends:
-        for other_cpu_backend in cpu_backends:
-            if cpu_backend != other_cpu_backend:
-                remove_parameter_value_pairs(
-                    expected_param_val_tuple,
-                    parameter1=cpu_backend,
-                    value_name1=cpu_backend,
-                    value_version1=ON,
-                    parameter2=other_cpu_backend,
-                    value_name2=other_cpu_backend,
-                    value_version2=OFF,
-                )
+    # cpu_backends = set(BACKENDS) - gpu_backends
+    # # remove all pairs, which contains two cpu backends and on of the backends is enabled and the
+    # # other is disabled
+    # for cpu_backend in cpu_backends:
+    #     for other_cpu_backend in cpu_backends:
+    #         if cpu_backend != other_cpu_backend:
+    #             remove_parameter_value_pairs(
+    #                 expected_param_val_tuple,
+    #                 parameter1=cpu_backend,
+    #                 value_name1=cpu_backend,
+    #                 value_version1=ON,
+    #                 parameter2=other_cpu_backend,
+    #                 value_name2=other_cpu_backend,
+    #                 value_version2=OFF,
+    #             )
 
     return check_parameter_value_pair_in_combination_list(
         combination_list, expected_param_val_tuple
@@ -112,31 +113,42 @@ def custom_filter(row: ParameterValueTuple) -> bool:
     Returns:
         bool: True if the tuple is valid
     """
-    gpu_backends = set(
-        [
-            ALPAKA_ACC_GPU_CUDA_ENABLE,
-            ALPAKA_ACC_GPU_HIP_ENABLE,
-            ALPAKA_ACC_SYCL_ENABLE,
-        ]
-    )
-    for single_gpu_backend in gpu_backends:
-        if single_gpu_backend in row and row[single_gpu_backend].version != OFF_VER:
-            for backend in BACKENDS:
-                if backend != single_gpu_backend:
-                    if backend in row and row[backend].version != OFF_VER:
-                        return False
 
-    cpu_backends = set(BACKENDS) - gpu_backends
-    for cpu_backend in cpu_backends:
-        if cpu_backend in row and row[cpu_backend].version == ON_VER:
-            # all other cpu backends needs to be enabled
-            for other_cpu_backend in cpu_backends - set(cpu_backend):
-                if other_cpu_backend in row and row[other_cpu_backend].version == OFF_VER:
-                    return False
-            # all other gpu backends needs to be disabled
-            for gpu_backend in gpu_backends:
-                if gpu_backend in row and row[gpu_backend].version != OFF_VER:
-                    return False
+    # TODO(SimeonEhrig): bring me back, if all GPU backend filter rules was implemented
+    # gpu_backends = set(
+    #     [
+    #         ALPAKA_ACC_GPU_CUDA_ENABLE,
+    #         ALPAKA_ACC_GPU_HIP_ENABLE,
+    #         ALPAKA_ACC_SYCL_ENABLE,
+    #     ]
+    # )
+    # for single_gpu_backend in gpu_backends:
+    #     if single_gpu_backend in row and row[single_gpu_backend].version != OFF_VER:
+    #         for backend in BACKENDS:
+    #             if backend != single_gpu_backend:
+    #                 if backend in row and row[backend].version != OFF_VER:
+    #                     return False
+
+    # gpu_backends = [ALPAKA_ACC_GPU_CUDA_ENABLE, ALPAKA_ACC_GPU_HIP_ENABLE, ALPAKA_ACC_SYCL_ENABLE]
+    # cpu_backends = set(BACKENDS) - set(gpu_backends)
+
+    # if (HOST_COMPILER in row and row[HOST_COMPILER].name in (HIPCC, ICPX, CLANG_CUDA)) or (
+    #     DEVICE_COMPILER in row and row[DEVICE_COMPILER].name in (NVCC, HIPCC, ICPX, CLANG_CUDA)
+    # ):
+    #     for cpu_backend in cpu_backends:
+    #         if cpu_backend in row and row[cpu_backend].version != OFF_VER:
+    #             return False
+
+    # for cpu_backend in cpu_backends:
+    #     if cpu_backend in row and row[cpu_backend].version == ON_VER:
+    #         # all other cpu backends needs to be enabled
+    #         for other_cpu_backend in cpu_backends - set(cpu_backend):
+    #             if other_cpu_backend in row and row[other_cpu_backend].version == OFF_VER:
+    #                 return False
+    #         # all other gpu backends needs to be disabled
+    #         for gpu_backend in gpu_backends:
+    #             if gpu_backend in row and row[gpu_backend].version != OFF_VER:
+    #                 return False
 
     return True
 

--- a/tests/test_clang_cuda.py
+++ b/tests/test_clang_cuda.py
@@ -1,0 +1,314 @@
+# pylint: disable=missing-docstring
+import unittest
+import io
+
+from typing import List, Tuple
+from collections import OrderedDict as OD
+import packaging.version as pkv
+from utils_test import parse_param_val as ppv
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.versions import VERSIONS, CLANG_CUDA_MAX_CUDA_VERSION
+from bashi.filter_compiler import compiler_filter_typechecked
+from bashi.filter_backend import backend_filter_typechecked
+
+
+class TestClangCUDACompilerFilter(unittest.TestCase):
+    def test_clang_cuda_requires_enabled_cuda_backend_c15(self):
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, 15)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+                        }
+                    )
+                )
+            )
+
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, 15)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "clang-cuda requires an enabled CUDA backend.")
+
+    def test_clang_cuda_supported_cuda_backends_c16(self):
+        self.assertEqual(
+            CLANG_CUDA_MAX_CUDA_VERSION[0].clang_cuda,
+            pkv.parse("17"),
+            "Modify this test, if a new supported Clang-CUDA version is added. Afterwards change "
+            "the last supported version of this assert.",
+        )
+
+        # because of rule c8, Clang-CUDA 13 and older is not supported
+        clang_cuda_sdk_combinations: List[Tuple[int, float, bool]] = [
+            (14, 12.2, False),
+            (14, 10.2, True),
+            (14, 11.5, True),
+            (14, 11.6, False),
+            (15, 11.5, True),
+            (15, 11.6, False),
+            (16, 11.8, True),
+            (16, 12.0, False),
+            (17, 12.1, True),
+            (17, 12.2, False),
+        ]
+
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            for (
+                clang_cuda_version,
+                cuda_sdk_version,
+                expected_filter_result,
+            ) in clang_cuda_sdk_combinations:
+                reason_msg1 = io.StringIO()
+
+                self.assertEqual(
+                    compiler_filter_typechecked(
+                        OD(
+                            {
+                                compiler_type: ppv((CLANG_CUDA, clang_cuda_version)),
+                                ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                    (ALPAKA_ACC_GPU_CUDA_ENABLE, cuda_sdk_version)
+                                ),
+                            }
+                        ),
+                        reason_msg1,
+                    ),
+                    expected_filter_result,
+                    f"Clang-CUDA {clang_cuda_version} + CUDA {cuda_sdk_version} -> "
+                    f"expected {expected_filter_result}",
+                )
+
+                if not expected_filter_result:
+                    self.assertEqual(
+                        reason_msg1.getvalue(),
+                        f"clang-cuda {clang_cuda_version} does not support "
+                        f"CUDA {cuda_sdk_version}.",
+                    )
+
+    def test_unsupported_new_clang_cuda_version_c16(self):
+        unsupported_new_clang_cuda_version = sorted(VERSIONS[CLANG_CUDA])[-1]
+        # only verify the following calculation
+        self.assertIsInstance(unsupported_new_clang_cuda_version, int)
+        unsupported_new_clang_cuda_version = int(unsupported_new_clang_cuda_version) + 1
+
+        unsupported_new_cuda_sdk_version = sorted(VERSIONS[NVCC])[-1]
+        # only verify the following calculation
+        self.assertIsInstance(unsupported_new_cuda_sdk_version, float)
+        unsupported_new_cuda_sdk_version = float(unsupported_new_cuda_sdk_version) + 1.0
+
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 9.0)),
+                        }
+                    ),
+                ),
+                f"clang-cuda {unsupported_new_clang_cuda_version} + CUDA 9.0",
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, sorted(VERSIONS[NVCC])[-1])
+                            ),
+                        }
+                    ),
+                ),
+                f"clang-cuda {unsupported_new_clang_cuda_version} + "
+                f"CUDA {sorted(VERSIONS[NVCC])[-1]}",
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, unsupported_new_cuda_sdk_version)
+                            ),
+                        }
+                    ),
+                ),
+                f"clang-cuda {unsupported_new_clang_cuda_version} + "
+                f"CUDA {unsupported_new_cuda_sdk_version}",
+            )
+
+    def test_clang_cuda_does_not_support_the_hip_backend_c17(self):
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, 15)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, 15)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "clang-cuda does not support the HIP backend.")
+
+    def test_clang_cuda_does_not_support_the_sycl_backend_c18(self):
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, 15)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, 15)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(), "clang-cuda does not support the SYCL backend."
+            )
+
+
+class TestClangCUDABackendFilter(unittest.TestCase):
+    def test_cuda_backend_supported_clang_cuda_version_b17(self):
+        self.assertEqual(
+            CLANG_CUDA_MAX_CUDA_VERSION[0].clang_cuda,
+            pkv.parse("17"),
+            "Modify this test, if a new supported Clang-CUDA version is added. Afterwards change "
+            "the last supported version of this assert.",
+        )
+
+        # because of rule c8, Clang-CUDA 13 and older is not supported
+        clang_cuda_sdk_combinations: List[Tuple[int, float, bool]] = [
+            (14, 12.2, False),
+            (14, 10.2, True),
+            (14, 11.5, True),
+            (14, 11.6, False),
+            (15, 11.5, True),
+            (15, 11.6, False),
+            (16, 11.8, True),
+            (16, 12.0, False),
+            (17, 12.1, True),
+            (17, 12.2, False),
+        ]
+
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            for (
+                clang_cuda_version,
+                cuda_sdk_version,
+                expected_filter_result,
+            ) in clang_cuda_sdk_combinations:
+                reason_msg1 = io.StringIO()
+                self.assertEqual(
+                    backend_filter_typechecked(
+                        OD(
+                            {
+                                compiler_type: ppv((CLANG_CUDA, clang_cuda_version)),
+                                ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                    (ALPAKA_ACC_GPU_CUDA_ENABLE, cuda_sdk_version)
+                                ),
+                            }
+                        ),
+                        reason_msg1,
+                    ),
+                    expected_filter_result,
+                    f"Clang-CUDA {clang_cuda_version} + CUDA {cuda_sdk_version} -> "
+                    f"expected {expected_filter_result}",
+                )
+
+                if not expected_filter_result:
+                    self.assertEqual(
+                        reason_msg1.getvalue(),
+                        f"CUDA {cuda_sdk_version} is not supported "
+                        f"by Clang-CUDA {clang_cuda_version}",
+                    )
+
+    def test_unsupported_new_clang_cuda_version_b17(self):
+        unsupported_new_clang_cuda_version = sorted(VERSIONS[CLANG_CUDA])[-1]
+        # only verify the following calculation
+        self.assertIsInstance(unsupported_new_clang_cuda_version, int)
+        unsupported_new_clang_cuda_version = int(unsupported_new_clang_cuda_version) + 1
+
+        unsupported_new_cuda_sdk_version = sorted(VERSIONS[NVCC])[-1]
+        # only verify the following calculation
+        self.assertIsInstance(unsupported_new_cuda_sdk_version, float)
+        unsupported_new_cuda_sdk_version = float(unsupported_new_cuda_sdk_version) + 1.0
+
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 9.0)),
+                        }
+                    ),
+                ),
+                f"clang-cuda {unsupported_new_clang_cuda_version} + CUDA 9.0",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, sorted(VERSIONS[NVCC])[-1])
+                            ),
+                        }
+                    ),
+                ),
+                f"clang-cuda {unsupported_new_clang_cuda_version} + "
+                f"CUDA {sorted(VERSIONS[NVCC])[-1]}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, unsupported_new_cuda_sdk_version)
+                            ),
+                        }
+                    ),
+                ),
+                f"clang-cuda {unsupported_new_clang_cuda_version} + "
+                f"CUDA {unsupported_new_cuda_sdk_version}",
+            )

--- a/tests/test_hipcc_filter.py
+++ b/tests/test_hipcc_filter.py
@@ -588,3 +588,223 @@ class TestHipccCompilerFilter(unittest.TestCase):
         self.assertEqual(
             reason_msg2.getvalue(), "The HIP and SYCL backend cannot be enabled on the same time."
         )
+
+    def test_hipcc_requires_disabled_cuda_backend_pass_c11(self):
+        for version in (4.5, 5.3, 6.0):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+    def test_hipcc_requires_disabled_cuda_backend_not_pass_c11(self):
+        for version in (4.5, 5.3, 6.0):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "hipcc does not support the CUDA backend.")
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg2,
+                )
+            )
+            self.assertEqual(reason_msg2.getvalue(), "hipcc does not support the CUDA backend.")
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg3,
+                )
+            )
+            self.assertEqual(reason_msg3.getvalue(), "hipcc does not support the CUDA backend.")
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                        }
+                    ),
+                    reason_msg4,
+                )
+            )
+            self.assertEqual(reason_msg4.getvalue(), "hipcc does not support the CUDA backend.")
+
+            reason_msg5 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg5,
+                )
+            )
+            self.assertEqual(reason_msg5.getvalue(), "hipcc does not support the CUDA backend.")
+
+    def test_hip_and_cuda_backend_cannot_be_active_at_the_same_time_b3(self):
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(
+            reason_msg1.getvalue(), "The HIP and CUDA backend cannot be enabled on the same time."
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg2 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+                reason_msg2,
+            )
+        )
+        self.assertEqual(
+            reason_msg2.getvalue(), "The HIP and CUDA backend cannot be enabled on the same time."
+        )

--- a/tests/test_hipcc_filter.py
+++ b/tests/test_hipcc_filter.py
@@ -1,0 +1,370 @@
+# pylint: disable=missing-docstring
+import unittest
+import io
+from collections import OrderedDict as OD
+from utils_test import parse_param_val as ppv
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.filter_compiler import compiler_filter_typechecked
+from bashi.filter_backend import backend_filter_typechecked
+
+
+class TestHipccCompilerFilter(unittest.TestCase):
+    def test_hipcc_requires_enabled_hip_backend_pass_c9(self):
+        for version in (4.5, 5.3, 6.0):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+    def test_hipcc_requires_enabled_hip_backend_not_pass_c9(self):
+        for version in (4.5, 5.3, 6.0):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "hipcc requires an enabled HIP backend.")
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg2,
+                )
+            )
+            self.assertEqual(reason_msg2.getvalue(), "hipcc requires an enabled HIP backend.")
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg3,
+                )
+            )
+            self.assertEqual(reason_msg3.getvalue(), "hipcc requires an enabled HIP backend.")
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                        }
+                    ),
+                    reason_msg4,
+                )
+            )
+            self.assertEqual(reason_msg4.getvalue(), "hipcc requires an enabled HIP backend.")
+
+            reason_msg5 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg5,
+                )
+            )
+            self.assertEqual(reason_msg5.getvalue(), "hipcc requires an enabled HIP backend.")
+
+    def test_check_if_hip_backend_is_disabled_for_no_hipcc_compiler_pass_b1(self):
+        for compiler_name in set(COMPILERS) - set([NVCC, HIPCC]):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_HIP_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_HIP_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_HIP_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_HIP_ENABLE should be off for {compiler_name}",
+            )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 9999)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                    }
+                )
+            ),
+            "ALPAKA_ACC_GPU_HIP_ENABLE should be off for nvcc",
+        )
+
+        for host_compiler in (GCC, CLANG):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_HIP_ENABLE should be off for nvcc + {host_compiler}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_HIP_ENABLE should be off for nvcc + {host_compiler}",
+            )
+
+    def test_check_if_hip_backend_is_disabled_for_no_hipcc_compiler_not_pass_b1(self):
+        for compiler_name in set(COMPILERS) - set([NVCC, HIPCC]):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_GPU_HIP_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(), "An enabled HIP backend requires hipcc as compiler."
+            )
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg2,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_GPU_HIP_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg2.getvalue(), "An enabled HIP backend requires hipcc as compiler."
+            )
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg3,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_GPU_HIP_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg3.getvalue(), "An enabled HIP backend requires hipcc as compiler."
+            )
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg4,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_GPU_HIP_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg4.getvalue(), "An enabled HIP backend requires hipcc as compiler."
+            )
+
+        reason_msg5 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 9999)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                    }
+                ),
+                reason_msg5,
+            ),
+            "nvcc should not pass the filter if ALPAKA_ACC_GPU_HIP_ENABLE is on",
+        )
+        self.assertEqual(
+            reason_msg5.getvalue(), "An enabled HIP backend requires hipcc as compiler."
+        )
+
+        for host_compiler in (GCC, CLANG):
+            reason_msg6 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg6,
+                ),
+                f"nvcc + {host_compiler} should not pass the filter if "
+                "ALPAKA_ACC_GPU_HIP_ENABLE is on",
+            )
+
+            reason_msg7 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg7,
+                ),
+                f"nvcc + {host_compiler} should not pass the filter if "
+                "ALPAKA_ACC_GPU_HIP_ENABLE is on",
+            )

--- a/tests/test_hipcc_filter.py
+++ b/tests/test_hipcc_filter.py
@@ -368,3 +368,223 @@ class TestHipccCompilerFilter(unittest.TestCase):
                 f"nvcc + {host_compiler} should not pass the filter if "
                 "ALPAKA_ACC_GPU_HIP_ENABLE is on",
             )
+
+    def test_hipcc_requires_disabled_sycl_backend_pass_c10(self):
+        for version in (4.5, 5.3, 6.0):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+    def test_hipcc_requires_disabled_sycl_backend_not_pass_c10(self):
+        for version in (4.5, 5.3, 6.0):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "hipcc does not support the SYCL backend.")
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg2,
+                )
+            )
+            self.assertEqual(reason_msg2.getvalue(), "hipcc does not support the SYCL backend.")
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg3,
+                )
+            )
+            self.assertEqual(reason_msg3.getvalue(), "hipcc does not support the SYCL backend.")
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                        }
+                    ),
+                    reason_msg4,
+                )
+            )
+            self.assertEqual(reason_msg4.getvalue(), "hipcc does not support the SYCL backend.")
+
+            reason_msg5 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((HIPCC, version)),
+                            DEVICE_COMPILER: ppv((HIPCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg5,
+                )
+            )
+            self.assertEqual(reason_msg5.getvalue(), "hipcc does not support the SYCL backend.")
+
+    def test_hip_and_sycl_backend_cannot_be_active_at_the_same_time_b2(self):
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(
+            reason_msg1.getvalue(), "The HIP and SYCL backend cannot be enabled on the same time."
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg2 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+                reason_msg2,
+            )
+        )
+        self.assertEqual(
+            reason_msg2.getvalue(), "The HIP and SYCL backend cannot be enabled on the same time."
+        )

--- a/tests/test_icpx_filter.py
+++ b/tests/test_icpx_filter.py
@@ -1,0 +1,810 @@
+# pylint: disable=missing-docstring
+import unittest
+import io
+from collections import OrderedDict as OD
+from utils_test import parse_param_val as ppv
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.filter_compiler import compiler_filter_typechecked
+from bashi.filter_backend import backend_filter_typechecked
+
+
+class TestIcpxCompilerFilter(unittest.TestCase):
+    def test_icpx_requires_enabled_sycl_backend_pass_c12(self):
+        for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    )
+                )
+            )
+
+    def test_icpx_requires_enabled_sycl_backend_not_pass_c12(self):
+        for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "icpx requires an enabled SYCL backend.")
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg2,
+                )
+            )
+            self.assertEqual(reason_msg2.getvalue(), "icpx requires an enabled SYCL backend.")
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg3,
+                )
+            )
+            self.assertEqual(reason_msg3.getvalue(), "icpx requires an enabled SYCL backend.")
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                        }
+                    ),
+                    reason_msg4,
+                )
+            )
+            self.assertEqual(reason_msg4.getvalue(), "icpx requires an enabled SYCL backend.")
+
+            reason_msg5 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg5,
+                )
+            )
+            self.assertEqual(reason_msg5.getvalue(), "icpx requires an enabled SYCL backend.")
+
+    def test_check_if_sycl_backend_is_disabled_for_no_sycl_compiler_pass_b4(self):
+        for compiler_name in set(COMPILERS) - set([NVCC, ICPX]):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_SYCL_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_SYCL_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_SYCL_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_SYCL_ENABLE should be off for {compiler_name}",
+            )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 9999)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                    }
+                )
+            ),
+            "ALPAKA_ACC_SYCL_ENABLE should be off for nvcc",
+        )
+
+        for host_compiler in (GCC, CLANG):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_SYCL_ENABLE should be off for nvcc + {host_compiler}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_SYCL_ENABLE should be off for nvcc + {host_compiler}",
+            )
+
+    def test_check_if_sycl_backend_is_disabled_for_no_icpx_compiler_not_pass_b4(self):
+        for compiler_name in set(COMPILERS) - set([NVCC, ICPX]):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_SYCL_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(), "An enabled SYCL backend requires icpx as compiler."
+            )
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg2,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_SYCL_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg2.getvalue(), "An enabled SYCL backend requires icpx as compiler."
+            )
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg3,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_SYCL_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg3.getvalue(), "An enabled SYCL backend requires icpx as compiler."
+            )
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg4,
+                ),
+                f"{compiler_name} should not pass the filter if ALPAKA_ACC_SYCL_ENABLE is on",
+            )
+            self.assertEqual(
+                reason_msg4.getvalue(), "An enabled SYCL backend requires icpx as compiler."
+            )
+
+        reason_msg5 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 9999)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+                reason_msg5,
+            ),
+            "nvcc should not pass the filter if ALPAKA_ACC_SYCL_ENABLE is on",
+        )
+        self.assertEqual(
+            reason_msg5.getvalue(), "An enabled SYCL backend requires icpx as compiler."
+        )
+
+        for host_compiler in (GCC, CLANG):
+            reason_msg6 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg6,
+                ),
+                f"nvcc + {host_compiler} should not pass the filter if "
+                "ALPAKA_ACC_SYCL_ENABLE is on",
+            )
+
+            reason_msg7 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((host_compiler, 9999)),
+                            DEVICE_COMPILER: ppv((NVCC, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg7,
+                ),
+                f"nvcc + {host_compiler} should not pass the filter if "
+                "ALPAKA_ACC_SYCL_ENABLE is on",
+            )
+
+    def test_sycl_requires_disabled_hip_backend_pass_c13(self):
+        for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+    def test_icpx_requires_disabled_hip_backend_not_pass_c13(self):
+        for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "icpx does not support the HIP backend.")
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg2,
+                )
+            )
+            self.assertEqual(reason_msg2.getvalue(), "icpx does not support the HIP backend.")
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg3,
+                )
+            )
+            self.assertEqual(reason_msg3.getvalue(), "icpx does not support the HIP backend.")
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                        }
+                    ),
+                    reason_msg4,
+                )
+            )
+            self.assertEqual(reason_msg4.getvalue(), "icpx does not support the HIP backend.")
+
+            reason_msg5 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg5,
+                )
+            )
+            self.assertEqual(reason_msg5.getvalue(), "icpx does not support the HIP backend.")
+
+    def test_sycl_and_hip_backend_cannot_be_active_at_the_same_time_b5(self):
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(
+            reason_msg1.getvalue(), "The HIP and SYCL backend cannot be enabled on the same time."
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg2 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+                reason_msg2,
+            )
+        )
+        self.assertEqual(
+            reason_msg2.getvalue(), "The HIP and SYCL backend cannot be enabled on the same time."
+        )
+
+    def test_icpx_requires_disabled_cuda_backend_pass_c14(self):
+        for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                )
+            )
+
+    def test_icpx_requires_disabled_cuda_backend_not_pass_c14(self):
+        for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(reason_msg1.getvalue(), "icpx does not support the CUDA backend.")
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg2,
+                )
+            )
+            self.assertEqual(reason_msg2.getvalue(), "icpx does not support the CUDA backend.")
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg3,
+                )
+            )
+            self.assertEqual(reason_msg3.getvalue(), "icpx does not support the CUDA backend.")
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                        }
+                    ),
+                    reason_msg4,
+                )
+            )
+            self.assertEqual(reason_msg4.getvalue(), "icpx does not support the CUDA backend.")
+
+            reason_msg5 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((ICPX, version)),
+                            DEVICE_COMPILER: ppv((ICPX, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                        }
+                    ),
+                    reason_msg5,
+                )
+            )
+            self.assertEqual(reason_msg5.getvalue(), "icpx does not support the CUDA backend.")
+
+    def test_sycl_and_cuda_backend_cannot_be_active_at_the_same_time_b6(self):
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(
+            reason_msg1.getvalue(), "The SYCL and CUDA backend cannot be enabled on the same time."
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg2 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
+                    }
+                ),
+                reason_msg2,
+            )
+        )
+        self.assertEqual(
+            reason_msg2.getvalue(), "The SYCL and CUDA backend cannot be enabled on the same time."
+        )

--- a/tests/test_nvcc_filter.py
+++ b/tests/test_nvcc_filter.py
@@ -953,8 +953,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         self.assertEqual(reason_msg2.getvalue(), "CUDA backend needs to be enabled for nvcc")
 
     def test_check_if_cuda_backend_is_disabled_for_no_cuda_compiler_pass_b7(self):
-        # TODO(SimeonEhrig): if we add CUDA SDK rules for Clang-CUDA, this test should fail
-        for compiler_name in set(COMPILERS) - set([NVCC]):
+        for compiler_name in set(COMPILERS) - set([NVCC, CLANG_CUDA]):
             self.assertTrue(
                 backend_filter_typechecked(
                     OD(

--- a/tests/test_nvcc_filter.py
+++ b/tests/test_nvcc_filter.py
@@ -8,6 +8,7 @@ from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.versions import VERSIONS, NvccHostSupport
 from bashi.filter_compiler import compiler_filter_typechecked
+from bashi.filter_backend import backend_filter_typechecked
 
 
 class TestNoNvccHostCompiler(unittest.TestCase):
@@ -727,3 +728,685 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
                     reason_msg.getvalue(),
                     "clang as host compiler is disabled for nvcc 11.3 to 11.5",
                 )
+
+
+class TestNvccCompilerFilter(unittest.TestCase):
+    def test_nvcc_requires_sane_cuda_backend_version_pass_c15(self):
+        for version in ("10.1", "11.2", "12.3"):
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((GCC, 7)),
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
+                            HOST_COMPILER: ppv((GCC, 7)),
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                        }
+                    )
+                )
+            )
+
+            self.assertTrue(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((CLANG, 6)),
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
+                        }
+                    )
+                )
+            )
+
+    def test_nvcc_requires_sane_cuda_backend_version_not_pass_c15(self):
+        for version in ("10.1", "11.2", "12.3"):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(), "nvcc and CUDA backend needs to have the same version"
+            )
+
+            reason_msg2 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, "11.8")),
+                        }
+                    ),
+                    reason_msg2,
+                )
+            )
+            self.assertEqual(
+                reason_msg2.getvalue(), "nvcc and CUDA backend needs to have the same version"
+            )
+
+            reason_msg3 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((GCC, 7)),
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    ),
+                    reason_msg3,
+                )
+            )
+            self.assertEqual(
+                reason_msg3.getvalue(), "nvcc and CUDA backend needs to have the same version"
+            )
+
+            reason_msg4 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.1)),
+                            HOST_COMPILER: ppv((GCC, 7)),
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                        }
+                    ),
+                    reason_msg4,
+                )
+            )
+            self.assertEqual(
+                reason_msg4.getvalue(), "nvcc and CUDA backend needs to have the same version"
+            )
+
+            reason_msg5 = io.StringIO()
+            self.assertFalse(
+                compiler_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((GCC, 7)),
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.0)),
+                        }
+                    ),
+                    reason_msg5,
+                )
+            )
+            self.assertEqual(
+                reason_msg5.getvalue(), "nvcc and CUDA backend needs to have the same version"
+            )
+
+    def test_nvcc_requires_disabled_hip_backend_c16(self):
+        self.assertTrue(
+            compiler_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 11.2)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            compiler_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 11.3)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(reason_msg1.getvalue(), "nvcc does not support the HIP backend.")
+
+    def test_nvcc_requires_disabled_sycl_backend_c17(self):
+        self.assertTrue(
+            compiler_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 11.2)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            compiler_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 11.3)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(reason_msg1.getvalue(), "nvcc does not support the SYCL backend.")
+
+    def test_disallow_disabled_cuda_backend_for_nvcc_device_compiler_b7(self):
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 12.2)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(reason_msg1.getvalue(), "CUDA backend needs to be enabled for nvcc")
+
+        reason_msg2 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        HOST_COMPILER: ppv((GCC, 9)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        DEVICE_COMPILER: ppv((NVCC, 12.2)),
+                    }
+                ),
+                reason_msg2,
+            )
+        )
+        self.assertEqual(reason_msg2.getvalue(), "CUDA backend needs to be enabled for nvcc")
+
+    def test_check_if_cuda_backend_is_disabled_for_no_cuda_compiler_pass_b7(self):
+        # TODO(SimeonEhrig): if we add CUDA SDK rules for Clang-CUDA, this test should fail
+        for compiler_name in set(COMPILERS) - set([NVCC]):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_CUDA_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_CUDA_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_CUDA_ENABLE should be off for {compiler_name}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            CMAKE: ppv((CMAKE, 3.18)),
+                            HOST_COMPILER: ppv((compiler_name, 9999)),
+                            DEVICE_COMPILER: ppv((compiler_name, 9999)),
+                            BOOST: ppv((BOOST, "1.78.0")),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        }
+                    )
+                ),
+                f"ALPAKA_ACC_GPU_CUDA_ENABLE should be off for {compiler_name}",
+            )
+
+    def test_check_if_cuda_backend_is_disabled_for_unsupported_host_compiler_b8(self):
+        for host_compiler, cuda_sdk in (
+            ((GCC, 7), (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+            ((CLANG, 7), (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.8)),
+            ((CLANG_CUDA, 16), (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.0)),
+            ((NVCC, 12.0), (ALPAKA_ACC_GPU_CUDA_ENABLE, 12.0)),
+        ):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((host_compiler[0], host_compiler[1])),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((cuda_sdk[0], cuda_sdk[1])),
+                        }
+                    )
+                ),
+                f"{host_compiler[0]} {host_compiler[1]} + CUDA {cuda_sdk[1]}",
+            )
+
+        for host_compiler, cuda_sdk in (
+            ((HIPCC, 5.1), (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+            ((ICPX, "2023.1.0"), (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.8)),
+        ):
+            reason_msg1 = io.StringIO()
+
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((host_compiler[0], host_compiler[1])),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((cuda_sdk[0], cuda_sdk[1])),
+                        }
+                    ),
+                    reason_msg1,
+                ),
+                f"{host_compiler[0]} {host_compiler[1]} + CUDA {cuda_sdk[1]}",
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(),
+                f"host-compiler {host_compiler[0]} does not support the CUDA backend",
+            )
+
+    def test_nvcc_and_cuda_backend_needs_same_version_b9(self):
+        for version in (10.1, 11.2, 12.3):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((NVCC, version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
+                        }
+                    ),
+                )
+            )
+
+        for version_nvcc, version_cuda in ((10.1, 10.2), (11.2, 10.1), (12.3, 12.2)):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((NVCC, version_nvcc)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, version_cuda)
+                            ),
+                        }
+                    ),
+                    reason_msg1,
+                )
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(), "CUDA backend and nvcc needs to have the same version"
+            )
+
+    def test_gcc_host_compiler_support_cuda_sdk_b10(self):
+        for gcc_version, version_cuda in ((5, 10.2), (9, 11.8), (11, 12.2)):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((GCC, gcc_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, version_cuda)
+                            ),
+                        }
+                    ),
+                ),
+                f"gcc {gcc_version} + CUDA {version_cuda}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((GCC, gcc_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, version_cuda)
+                            ),
+                            DEVICE_COMPILER: ppv((NVCC, version_cuda)),
+                        }
+                    ),
+                ),
+                f"gcc {gcc_version} + CUDA {version_cuda}",
+            )
+
+        for gcc_version, version_cuda in ((12, 10.2), (15, 11.8), (13, 12.2)):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((GCC, gcc_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, version_cuda)
+                            ),
+                        }
+                    ),
+                    reason_msg1,
+                ),
+                f"gcc {gcc_version} + CUDA {version_cuda}",
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(), f"CUDA {version_cuda} does not support gcc {gcc_version}"
+            )
+
+    def test_no_clang_compiler_for_cuda_113_to_115_b11(self):
+        for clang_version in (7, 9, 12):
+            for cuda_version in (11.3, 11.4, 11.5):
+                reason_msg1 = io.StringIO()
+                self.assertFalse(
+                    backend_filter_typechecked(
+                        OD(
+                            {
+                                HOST_COMPILER: ppv((CLANG, clang_version)),
+                                ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                    (ALPAKA_ACC_GPU_CUDA_ENABLE, cuda_version)
+                                ),
+                            }
+                        ),
+                        reason_msg1,
+                    ),
+                    f"clang {clang_version} + CUDA {cuda_version}",
+                )
+                self.assertEqual(
+                    reason_msg1.getvalue(),
+                    "clang as host compiler is disabled for CUDA 11.3 to 11.5",
+                )
+
+    def test_clang_host_compiler_support_cuda_sdk_b12(self):
+        for clang_version, version_cuda in ((5, 10.2), (9, 11.8), (11, 12.2)):
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG, clang_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, version_cuda)
+                            ),
+                        }
+                    ),
+                ),
+                f"clang {clang_version} + CUDA {version_cuda}",
+            )
+
+            self.assertTrue(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG, clang_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, version_cuda)
+                            ),
+                            DEVICE_COMPILER: ppv((NVCC, version_cuda)),
+                        }
+                    ),
+                ),
+                f"clang {clang_version} + CUDA {version_cuda}",
+            )
+
+        for clang_version, version_cuda in ((12, 10.2), (15, 11.8), (17, 12.2)):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG, clang_version)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
+                                (ALPAKA_ACC_GPU_CUDA_ENABLE, version_cuda)
+                            ),
+                        }
+                    ),
+                    reason_msg1,
+                ),
+                f"clang {clang_version} + CUDA {version_cuda}",
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(),
+                f"CUDA {version_cuda} does not support clang {clang_version}",
+            )
+
+    def test_unsupported_cuda_device_compiler_b13(self):
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((NVCC, 11.2)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+                    }
+                ),
+            ),
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        DEVICE_COMPILER: ppv((CLANG_CUDA, 15)),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+                    }
+                ),
+            ),
+        )
+
+        for device_compiler in set(COMPILERS) - set([NVCC, CLANG_CUDA]):
+            reason_msg1 = io.StringIO()
+            self.assertFalse(
+                backend_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((device_compiler, 7)),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
+                        }
+                    ),
+                    reason_msg1,
+                ),
+                f"device-compiler {DEVICE_COMPILER} + CUDA 11.2",
+            )
+            self.assertEqual(
+                reason_msg1.getvalue(),
+                f"{device_compiler} does not support the CUDA backend",
+            )
+
+    def test_cuda_and_hip_backend_cannot_be_active_at_the_same_time_b14(self):
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.4)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.7)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(
+            reason_msg1.getvalue(), "The HIP and CUDA backend cannot be enabled on the same time."
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 10.2)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg2 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.3)),
+                    }
+                ),
+                reason_msg2,
+            )
+        )
+        self.assertEqual(
+            reason_msg2.getvalue(), "The HIP and CUDA backend cannot be enabled on the same time."
+        )
+
+    def test_cuda_and_sycl_backend_cannot_be_active_at_the_same_time_b15(self):
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.4)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                    }
+                ),
+            )
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg1 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.7)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                    }
+                ),
+                reason_msg1,
+            )
+        )
+        self.assertEqual(
+            reason_msg1.getvalue(), "The SYCL and CUDA backend cannot be enabled on the same time."
+        )
+
+        self.assertTrue(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, OFF)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 10.2)),
+                    }
+                ),
+            )
+        )
+
+        reason_msg2 = io.StringIO()
+        self.assertFalse(
+            backend_filter_typechecked(
+                OD(
+                    {
+                        CMAKE: ppv((CMAKE, 3.18)),
+                        ALPAKA_ACC_SYCL_ENABLE: ppv((ALPAKA_ACC_SYCL_ENABLE, ON)),
+                        BOOST: ppv((BOOST, "1.78.0")),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.3)),
+                    }
+                ),
+                reason_msg2,
+            )
+        )
+        self.assertEqual(
+            reason_msg2.getvalue(), "The SYCL and CUDA backend cannot be enabled on the same time."
+        )

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -22,6 +22,8 @@ from bashi.results import (
     _remove_unsupported_compiler_for_hip_backend,
     _remove_disabled_hip_backend_for_hipcc,
     _remove_enabled_sycl_backend_for_hipcc,
+    _remove_enabled_cuda_backend_for_hipcc,
+    _remove_enabled_cuda_backend_for_enabled_hip_backend,
 )
 from bashi.versions import NvccHostSupport, NVCC_GCC_MAX_VERSION
 
@@ -943,6 +945,174 @@ class TestExpectedBashiParameterValuesPairsHIPBackend(unittest.TestCase):
                         {
                             DEVICE_COMPILER: (NVCC, 11.2),
                             ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_enabled_cuda_backend_for_hipcc(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 10.1),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (HIPCC, 5.1),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (HIPCC, 5.3),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 6.0),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 6.1),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 12.0),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_enabled_cuda_backend_for_hipcc(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (CLANG_CUDA, 16),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 10.1),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (GCC, 10),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (HIPCC, 5.1),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (HIPCC, 6.0),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (NVCC, 11.2),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_enabled_cuda_backend_for_enabled_hip_backend(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_enabled_cuda_backend_for_enabled_hip_backend(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
                         }
                     ),
                     OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -19,6 +19,8 @@ from bashi.results import (
     _remove_nvcc_unsupported_gcc_versions,
     _remove_nvcc_unsupported_clang_versions,
     _remove_specific_nvcc_clang_combinations,
+    _remove_unsupported_compiler_for_hip_backend,
+    _remove_disabled_hip_backend_for_hipcc,
 )
 from bashi.versions import NvccHostSupport, NVCC_GCC_MAX_VERSION
 
@@ -677,6 +679,164 @@ class TestExpectedBashiParameterValuesPairsNvccHostCompilerVersions(unittest.Tes
                             ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 12.2),
                         }
                     ),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+
+class TestExpectedBashiParameterValuesPairsHIPBackend(unittest.TestCase):
+    def test_remove_unsupported_compiler_for_hip_backend(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (HIPCC, 5.1),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 6.0),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_unsupported_compiler_for_hip_backend(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (HIPCC, 5.1),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (HIPCC, 6.0),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_disabled_hip_backend_for_hipcc(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (HIPCC, 5.1),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 6.0),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_disabled_hip_backend_for_hipcc(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (CLANG_CUDA, 16),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (GCC, 10),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (NVCC, 11.2),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
                 ]
             )
         )

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -21,6 +21,7 @@ from bashi.results import (
     _remove_specific_nvcc_clang_combinations,
     _remove_unsupported_compiler_for_hip_backend,
     _remove_disabled_hip_backend_for_hipcc,
+    _remove_enabled_sycl_backend_for_hipcc,
 )
 from bashi.versions import NvccHostSupport, NVCC_GCC_MAX_VERSION
 
@@ -834,6 +835,114 @@ class TestExpectedBashiParameterValuesPairsHIPBackend(unittest.TestCase):
                         {
                             DEVICE_COMPILER: (NVCC, 11.2),
                             ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_enabled_sycl_backend_for_hipcc(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 4.3),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (HIPCC, 5.1),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 6.0),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 5.7),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+            ]
+        )
+
+        _remove_enabled_sycl_backend_for_hipcc(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (CLANG_CUDA, 16),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (GCC, 10),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (HIPCC, 5.1),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (HIPCC, 6.0),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (NVCC, 11.2),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
                         }
                     ),
                     OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -24,6 +24,11 @@ from bashi.results import (
     _remove_enabled_sycl_backend_for_hipcc,
     _remove_enabled_cuda_backend_for_hipcc,
     _remove_enabled_cuda_backend_for_enabled_hip_backend,
+    _remove_unsupported_compiler_for_sycl_backend,
+    _remove_disabled_sycl_backend_for_icpx,
+    _remove_enabled_hip_backend_for_icpx,
+    _remove_enabled_cuda_backend_for_icpx,
+    _remove_enabled_cuda_backend_for_enabled_sycl_backend,
 )
 from bashi.versions import NvccHostSupport, NVCC_GCC_MAX_VERSION
 
@@ -1112,6 +1117,446 @@ class TestExpectedBashiParameterValuesPairsHIPBackend(unittest.TestCase):
                     OD(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+
+class TestExpectedBashiParameterValuesPairsSYCLBackend(unittest.TestCase):
+    def test_remove_unsupported_compiler_for_sycl_backend(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 5.1),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2024.2.0"),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_unsupported_compiler_for_sycl_backend(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (ICPX, "2023.1.0"),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (ICPX, "2024.2.0"),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_disabled_sycl_backend_for_icpx(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 5.1),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2024.2.0"),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_disabled_sycl_backend_for_icpx(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (CLANG_CUDA, 16),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (GCC, 10),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (HIPCC, 5.1),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (NVCC, 11.2),
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_enabled_hip_backend_for_icpx(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (ICPX, "2024.2.0"),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 5.1),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2024.2.1"),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 5.7),
+                        ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                    }
+                ),
+            ]
+        )
+
+        _remove_enabled_hip_backend_for_icpx(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (CLANG_CUDA, 16),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (GCC, 10),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (ICPX, "2023.1.0"),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (ICPX, "2024.2.0"),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (HIPCC, 5.1),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (NVCC, 11.2),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (HIPCC, 5.7),
+                            ALPAKA_ACC_GPU_HIP_ENABLE: (ALPAKA_ACC_GPU_HIP_ENABLE, ON),
+                        }
+                    ),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_enabled_cuda_backend_for_icpx(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        HOST_COMPILER: (CLANG_CUDA, 16),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 10.1),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (GCC, 10),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (ICPX, "2023.1.0"),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        HOST_COMPILER: (ICPX, "2024.2.0"),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (HIPCC, 4.5),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2024.2.1"),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (ICPX, "2024.8.3"),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 12.0),
+                    }
+                ),
+                OD(
+                    {
+                        DEVICE_COMPILER: (NVCC, 11.2),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_enabled_cuda_backend_for_icpx(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            HOST_COMPILER: (CLANG_CUDA, 16),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 10.1),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (GCC, 10),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            HOST_COMPILER: (ICPX, "2023.1.0"),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (HIPCC, 4.5),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (ICPX, "2024.2.1"),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            DEVICE_COMPILER: (NVCC, 11.2),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                        }
+                    ),
+                    OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+                ]
+            )
+        )
+
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_enabled_cuda_backend_for_enabled_sycl_backend(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                    }
+                ),
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD(
+                    {
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                    }
+                ),
+                OD(
+                    {
+                        ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
+                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
+                    }
+                ),
+                OD({CMAKE: (CMAKE, 3.23), BOOST: (BOOST, 1.83)}),
+            ]
+        )
+
+        _remove_enabled_cuda_backend_for_enabled_sycl_backend(test_param_value_pairs)
+
+        test_param_value_pairs.sort()
+        expected_results = sorted(
+            parse_expected_val_pairs(
+                [
+                    OD(
+                        {
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, ON),
+                            ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                        }
+                    ),
+                    OD(
+                        {
+                            ALPAKA_ACC_SYCL_ENABLE: (ALPAKA_ACC_SYCL_ENABLE, OFF),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2),
                         }
                     ),


### PR DESCRIPTION
Implement backend related rules for the following compilers

- [x] `hipcc` (`HIP`)
- [x] `icpx` (`sycl`)
- [x] `nvcc` (`CUDA`)
- [x] `clang-cuda` (`CUDA`)
- [x] fix example