### PR TITLE
bashi-validate: remove required parameter

### DIFF
--- a/bashi/filter_backend.py
+++ b/bashi/filter_backend.py
@@ -7,18 +7,9 @@ These identifiers are used in the test names, for example, to make it clear whic
 which rule.
 """
 
-from typing import Optional, IO, List
+from typing import Optional, IO
 from typeguard import typechecked
-from bashi.types import Parameter, ParameterValueTuple
-
-
-def get_required_parameters() -> List[Parameter]:
-    """Return list of parameters which will be checked in the filter.
-
-    Returns:
-        List[Parameter]: list of checked parameters
-    """
-    return []
+from bashi.types import ParameterValueTuple
 
 
 @typechecked

--- a/bashi/filter_compiler.py
+++ b/bashi/filter_compiler.py
@@ -7,25 +7,16 @@ These identifiers are used in the test names, for example, to make it clear whic
 which rule.
 """
 
-from typing import Optional, IO, List
+from typing import Optional, IO
 import packaging.version as pkv
 from typeguard import typechecked
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from bashi.types import Parameter, ParameterValueTuple
+from bashi.types import ParameterValueTuple
 from bashi.versions import NVCC_GCC_MAX_VERSION, NVCC_CLANG_MAX_VERSION
 from bashi.utils import reason
 
 # uncomment me for debugging
 # from bashi.utils import print_row_nice
-
-
-def get_required_parameters() -> List[Parameter]:
-    """Return list of parameters which will be checked in the filter.
-
-    Returns:
-        List[Parameter]: list of checked parameters
-    """
-    return [HOST_COMPILER, DEVICE_COMPILER]
 
 
 @typechecked

--- a/bashi/filter_software_dependency.py
+++ b/bashi/filter_software_dependency.py
@@ -7,18 +7,9 @@ These identifiers are used in the test names, for example, to make it clear whic
 which rule.
 """
 
-from typing import Optional, IO, List
+from typing import Optional, IO
 from typeguard import typechecked
-from bashi.types import Parameter, ParameterValueTuple
-
-
-def get_required_parameters() -> List[Parameter]:
-    """Return list of parameters which will be checked in the filter.
-
-    Returns:
-        List[Parameter]: list of checked parameters
-    """
-    return []
+from bashi.types import ParameterValueTuple
 
 
 @typechecked

--- a/bashi/validate.py
+++ b/bashi/validate.py
@@ -182,7 +182,6 @@ def get_args() -> Namespace:
 def check_single_filter(
     filter_func: Callable[[ParameterValueTuple, Optional[IO[str]]], bool],
     row: ParameterValueTuple,
-    required_parameter: List[str],
 ) -> bool:
     """Check if row passes a filter function.
 
@@ -194,8 +193,6 @@ def check_single_filter(
     Returns:
         bool: True if the row passes the filter.
     """
-    missing_parameters = ""
-
     # get name of the filter for command line output.
     filter_name: str = filter_func.__name__
 
@@ -203,20 +200,6 @@ def check_single_filter(
     # Remove _typed for better output.
     if filter_name.endswith("_typechecked"):
         filter_name = filter_name[: -len("_typechecked")]
-
-    # check if all required parameter are available
-    for req_name in required_parameter:
-        if req_name not in row:
-            missing_parameters += " " + req_name
-
-    if missing_parameters:
-        print(
-            cs(
-                f"skipped {filter_name}(), missing parameters ->" + missing_parameters,
-                "Yellow",
-            )
-        )
-        return False
 
     msg = io.StringIO()
 
@@ -245,21 +228,18 @@ def check_filter_chain(row: ParameterValueTuple) -> bool:
         check_single_filter(
             bashi.filter_compiler.compiler_filter,
             row,
-            bashi.filter_compiler.get_required_parameters(),
         )
     )
     all_true += int(
         check_single_filter(
             bashi.filter_backend.backend_filter_typechecked,
             row,
-            bashi.filter_backend.get_required_parameters(),
         )
     )
     all_true += int(
         check_single_filter(
             bashi.filter_software_dependency.software_dependency_filter_typechecked,
             row,
-            bashi.filter_software_dependency.get_required_parameters(),
         )
     )
 


### PR DESCRIPTION
Removed required parameter because the filter works different compare to the original implementation from `alpaka-job-matrix-library`, where the implementation is coming from. Now the ordering of the parameters in a row is not fixed anymore. The filter rules also checks only for two parameter at the same time an tries to cancel an invalid combination early as possible.