### PR TITLE
filter rule: CMake <=3.18 does not support Clang-CUDA

### DIFF
--- a/src/bashi/results.py
+++ b/src/bashi/results.py
@@ -78,6 +78,9 @@ def get_expected_bashi_parameter_value_pairs(
     _remove_unsupported_gcc_versions_for_ubuntu2004(
         param_val_pair_list, removed_param_val_pair_list
     )
+    _remove_unsupported_cmake_versions_for_clangcuda(
+        param_val_pair_list, removed_param_val_pair_list
+    )
     return (param_val_pair_list, removed_param_val_pair_list)
 
 
@@ -772,3 +775,20 @@ def _remove_unsupported_gcc_versions_for_ubuntu2004(
                 value_name2=UBUNTU,
                 value_version2="<20.04",
             )
+
+
+def _remove_unsupported_cmake_versions_for_clangcuda(
+    parameter_value_pairs: List[ParameterValuePair],
+    removed_parameter_value_pairs: List[ParameterValuePair],
+):
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        remove_parameter_value_pairs(
+            parameter_value_pairs,
+            removed_parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=CLANG_CUDA,
+            value_version1=ANY_VERSION,
+            parameter2=CMAKE,
+            value_name2=CMAKE,
+            value_version2=">3.18",
+        )

--- a/tests/test_filter_software_dependency.py
+++ b/tests/test_filter_software_dependency.py
@@ -133,3 +133,59 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
                 reason_msg.getvalue(),
                 f"device compiler GCC {gcc_version} is not available in Ubuntu 22.04",
             )
+
+    def test_valid_cmake_versions_for_clangcuda_d2(self):
+        for cmake_version in ["3.19", "3.26", "3.20", "3.49"]:
+            self.assertTrue(
+                software_dependency_filter_typechecked(
+                    OD(
+                        {
+                            HOST_COMPILER: ppv((CLANG_CUDA, 14)),
+                            CMAKE: ppv((CMAKE, cmake_version)),
+                        }
+                    ),
+                )
+            )
+
+        for cmake_version in ["3.19", "3.26", "3.20", "3.49"]:
+            self.assertTrue(
+                software_dependency_filter_typechecked(
+                    OD(
+                        {
+                            DEVICE_COMPILER: ppv((CLANG_CUDA, 15)),
+                            CMAKE: ppv((CMAKE, cmake_version)),
+                        }
+                    ),
+                )
+            )
+
+    def test_not_valid_cmake_versions_for_clangcuda_d2(self):
+        for cmake_version in ["3.9", "3.11", "3.17", "3.18"]:
+            reason_msg = io.StringIO()
+            self.assertFalse(
+                software_dependency_filter_typechecked(
+                    OD({HOST_COMPILER: ppv((CLANG_CUDA, 14)), CMAKE: ppv((CMAKE, cmake_version))}),
+                    reason_msg,
+                ),
+                f"host compiler CLANG_CUDA + CMAKE {cmake_version}",
+            )
+            self.assertEqual(
+                reason_msg.getvalue(),
+                f"host compiler CLANG_CUDA is not available in CMAKE {cmake_version}",
+            )
+
+        for cmake_version in ["3.9", "3.11", "3.17", "3.18"]:
+            reason_msg = io.StringIO()
+            self.assertFalse(
+                software_dependency_filter_typechecked(
+                    OD(
+                        {DEVICE_COMPILER: ppv((CLANG_CUDA, 15)), CMAKE: ppv((CMAKE, cmake_version))}
+                    ),
+                    reason_msg,
+                ),
+                f"device compiler CLANG_CUDA + CMAKE {cmake_version}",
+            )
+            self.assertEqual(
+                reason_msg.getvalue(),
+                f"device compiler CLANG_CUDA is not available in CMAKE {cmake_version}",
+            )

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -43,6 +43,7 @@ from bashi.results import (
     _remove_specific_cuda_clang_combinations,
     _remove_unsupported_clang_sdk_versions_for_clang_cuda,
     _remove_unsupported_gcc_versions_for_ubuntu2004,
+    _remove_unsupported_cmake_versions_for_clangcuda,
 )
 from bashi.versions import NvccHostSupport, NVCC_GCC_MAX_VERSION
 
@@ -2293,6 +2294,59 @@ class TestExpectedBashiParameterValuesPairsNvccCudaBackend(unittest.TestCase):
         )
         default_remove_test(
             _remove_unsupported_gcc_versions_for_ubuntu2004,
+            test_param_value_pairs,
+            expected_results,
+            self,
+        )
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_unsupported_cmake_versions_for_clangcuda(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+            [
+                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.19")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.20")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 15), CMAKE: (CMAKE, "3.18")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.21")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.26")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 12), CMAKE: (CMAKE, "3.18")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.46")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 12), CMAKE: (CMAKE, "3.1")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 12), CMAKE: (CMAKE, "3.18")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.19")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 15), CMAKE: (CMAKE, "3.20")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.14")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.12")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.9")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 17), CMAKE: (CMAKE, "3.19")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.17")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.26")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.30")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 16), CMAKE: (CMAKE, "3.40")}),
+                OD({HOST_COMPILER: (GCC, 12), UBUNTU: (UBUNTU, "22.04")}),
+            ]
+        )
+        expected_results = parse_expected_val_pairs(
+            [
+                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.19")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.19")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 17), CMAKE: (CMAKE, "3.19")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.20")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.30")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 16), CMAKE: (CMAKE, "3.40")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.21")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.26")}),
+                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.46")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 15), CMAKE: (CMAKE, "3.20")}),
+                OD({DEVICE_COMPILER: (CLANG_CUDA, 13), CMAKE: (CMAKE, "3.26")}),
+                OD({HOST_COMPILER: (GCC, 12), UBUNTU: (UBUNTU, 22.04)}),
+            ]
+        )
+        default_remove_test(
+            _remove_unsupported_cmake_versions_for_clangcuda,
             test_param_value_pairs,
             expected_results,
             self,


### PR DESCRIPTION
fix: #34