### PR TITLE
implement parse_expected_val_pairs2()

### DIFF
--- a/src/bashi/globals.py
+++ b/src/bashi/globals.py
@@ -54,3 +54,13 @@ ON_VER: ValueVersion = packaging.version.parse(ON)
 ANY_PARAM: Parameter = "*"
 ANY_NAME: ValueName = "*"
 ANY_VERSION: str = "*"
+
+# List of all supported parameters
+PARAMETERS: List[Parameter] = [
+    HOST_COMPILER,
+    DEVICE_COMPILER,
+    UBUNTU,
+    CMAKE,
+    BOOST,
+    CXX_STANDARD,
+] + BACKENDS

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -8,6 +8,7 @@ import packaging.version as pkv
 from utils_test import (
     parse_expected_val_pairs,
     create_diff_parameter_value_pairs,
+    parse_expected_val_pairs2,
     default_remove_test,
 )
 
@@ -2582,238 +2583,54 @@ class TestExpectedBashiParameterValuesPairsNvccCudaBackend(unittest.TestCase):
         )
 
     def test_remove_unsupported_cuda_versions_for_ubuntu(self):
-        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs(
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs2(
             [
-                OD({HOST_COMPILER: (GCC, 12), UBUNTU: (UBUNTU, 22.04)}),
-                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.19")}),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "22.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "22.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "12"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.2"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "11"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "11.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "14.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "7.4"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        DEVICE_COMPILER: (NVCC, "11.2"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (NVCC, "12"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (NVCC, "10.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "22.04"),
-                        DEVICE_COMPILER: (NVCC, "10"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "10"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "10.2"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "11"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "22.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "12"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "13"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        DEVICE_COMPILER: (NVCC, "10.2"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (NVCC, "10.2"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (NVCC, "11"),
-                    }
-                ),
+                ((HOST_COMPILER, GCC, 12), (UBUNTU, 22.04)),
+                ((HOST_COMPILER, CLANG_CUDA, 14), (CMAKE, "3.19")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1")),
+                ((UBUNTU, "22.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1")),
+                ((UBUNTU, "22.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "12")),
+                ((UBUNTU, "18.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.2")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "11")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "11.1")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "14.1")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "7.4")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                ((UBUNTU, "18.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                ((UBUNTU, "18.04"), (DEVICE_COMPILER, NVCC, "11.2")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, NVCC, "12")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, NVCC, "10.1")),
+                ((UBUNTU, "22.04"), (DEVICE_COMPILER, NVCC, "10")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, CLANG_CUDA, "10")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, CLANG_CUDA, "10.2")),
+                ((UBUNTU, "18.04"), (DEVICE_COMPILER, CLANG_CUDA, "11")),
+                ((UBUNTU, "22.04"), (DEVICE_COMPILER, CLANG_CUDA, "12")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, CLANG_CUDA, "13")),
+                ((UBUNTU, "18.04"), (DEVICE_COMPILER, NVCC, "10.2")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, NVCC, "10.2")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, NVCC, "11")),
             ]
         )
-        expected_results = parse_expected_val_pairs(
+
+        expected_results: List[ParameterValuePair] = parse_expected_val_pairs2(
             [
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (NVCC, "11"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "11"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "11"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "22.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "12"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (CLANG_CUDA, "13"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        DEVICE_COMPILER: (NVCC, "10.2"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        DEVICE_COMPILER: (NVCC, "11.2"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        DEVICE_COMPILER: (NVCC, "12"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "22.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "12"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "18.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "14.1"),
-                    }
-                ),
-                OD(
-                    {
-                        UBUNTU: (UBUNTU, "20.04"),
-                        ALPAKA_ACC_GPU_CUDA_ENABLE: (ALPAKA_ACC_GPU_CUDA_ENABLE, "11.1"),
-                    }
-                ),
-                OD({HOST_COMPILER: (GCC, 12), UBUNTU: (UBUNTU, 22.04)}),
-                OD({HOST_COMPILER: (CLANG_CUDA, 14), CMAKE: (CMAKE, "3.19")}),
+                ((HOST_COMPILER, GCC, 12), (UBUNTU, 22.04)),
+                ((HOST_COMPILER, CLANG_CUDA, 14), (CMAKE, "3.19")),
+                ((UBUNTU, "22.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "12")),
+                ((UBUNTU, "18.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "11")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "11.1")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "14.1")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                ((UBUNTU, "18.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
+                ((UBUNTU, "18.04"), (DEVICE_COMPILER, NVCC, "11.2")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, NVCC, "12")),
+                ((UBUNTU, "18.04"), (DEVICE_COMPILER, CLANG_CUDA, "11")),
+                ((UBUNTU, "22.04"), (DEVICE_COMPILER, CLANG_CUDA, "12")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, CLANG_CUDA, "13")),
+                ((UBUNTU, "18.04"), (DEVICE_COMPILER, NVCC, "10.2")),
+                ((UBUNTU, "20.04"), (DEVICE_COMPILER, NVCC, "11")),
             ]
         )
         default_remove_test(

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,7 @@
 """Different helper functions for bashi tests."""
 
 import unittest
-from typing import List, Union, Tuple, Callable
+from typing import List, Union, Tuple, Callable, TypeAlias
 from collections import OrderedDict
 import packaging.version as pkv
 from typeguard import typechecked
@@ -12,6 +12,7 @@ from bashi.types import (
     ValueName,
 )
 from bashi.utils import create_parameter_value_pair
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 
 def parse_param_val(param_val: Tuple[ValueName, Union[str, int, float]]) -> ParameterValue:
@@ -51,6 +52,8 @@ def parse_expected_val_pairs(
 ) -> List[ParameterValuePair]:
     """Parse list of expected parameter-values to the correct type.
 
+    Note: please use parse_expected_val_pairs2, which has a better interface
+
     Args:
         input_list (List[OrderedDict[Parameter, Tuple[ValueName, Union[str, int, float]]]]):
             List to parse
@@ -78,6 +81,87 @@ def parse_expected_val_pairs(
                 param2,
                 val_name2,
                 val_version2,
+            )
+        )
+
+    return expected_val_pairs
+
+
+RegularParsableParameterValue: TypeAlias = Tuple[str, str, Union[str, int, float]]
+CompilerParsableParameterValue: TypeAlias = Tuple[str, str, Union[str, int, float]]
+DefaultParsableParameterValue: TypeAlias = Tuple[str, Union[str, int, float]]
+ParsableParameterValue: TypeAlias = Union[
+    DefaultParsableParameterValue, CompilerParsableParameterValue
+]
+
+
+def parse_expected_val_pairs2(
+    input_list: List[Tuple[ParsableParameterValue, ParsableParameterValue]]
+) -> List[ParameterValuePair]:
+    """Parse list of expected parameter-values to the correct type.
+
+    Args:
+        input_list (List[Tuple[ParsableParameterValue, ParsableParameterValue]]):
+            e.g.:
+            parse_expected_val_pairs2(
+            [
+                ((HOST_COMPILER, GCC, 12), (UBUNTU, 22.04)),
+                ((HOST_COMPILER, CLANG_CUDA, 14), (CMAKE, "3.19")),
+                ((UBUNTU, "20.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1")),
+                ((UBUNTU, "22.04"), (ALPAKA_ACC_GPU_CUDA_ENABLE, "10.1")),
+            ])
+
+    Returns:
+        List[ParameterValuePair]: Parsed parameter-type list
+    """
+    expected_val_pairs: List[ParameterValuePair] = []
+    for pair_number, input_pair in enumerate(input_list):
+        if not isinstance(input_pair, tuple):
+            raise TypeError(f"{input_pair}\ninput_list[{pair_number}] is not a tuple")
+        if len(input_pair) != 2:
+            raise ValueError(
+                f"{input_pair}\ninput_list[{pair_number}] needs to be a tuple with two entries."
+            )
+
+        regular_entry_pair: List[RegularParsableParameterValue] = []
+        for entry_number, input_entry in enumerate(input_pair):
+            if input_entry[0] not in PARAMETERS:
+                raise ValueError(
+                    f"input_list[{pair_number}][{entry_number}][0] {input_entry}\n"
+                    "Parameter is unknown.\n"
+                )
+
+            if input_entry[0] in (HOST_COMPILER, DEVICE_COMPILER):
+                if len(input_entry) != 3:
+                    raise ValueError(
+                        f"input_list[{pair_number}][{entry_number}] {input_entry}\n"
+                        "First value is HOST_COMPILER or DEVICE_COMPILER.\n"
+                        "Therefore the tuple needs to contain three entries:"
+                        "\n(<HOST_COMPILER|DEVICE_COMPILER>, <value-name>, <value-version>)"
+                    )
+                if input_entry[1] not in COMPILERS:
+                    raise ValueError(
+                        f"input_list[{pair_number}][{entry_number}][1] {input_entry}\n"
+                        "Compiler is unknown.\n"
+                    )
+                regular_entry_pair.append(input_entry)
+            else:
+                if len(input_entry) != 2:
+                    raise ValueError(
+                        f"input_list[{pair_number}][{entry_number}] {input_entry}\n"
+                        "The tuple needs to contain two entries:"
+                        "\n(<parameter>, <value-version>)"
+                    )
+                regular_entry_pair.append((input_entry[0], input_entry[0], input_entry[1]))
+
+        expected_val_pairs.append(
+            create_parameter_value_pair(
+                regular_entry_pair[0][0],
+                regular_entry_pair[0][1],
+                regular_entry_pair[0][2],
+                regular_entry_pair[1][0],
+                regular_entry_pair[1][1],
+                regular_entry_pair[1][2],
             )
         )
 


### PR DESCRIPTION
Same functionality like `parse_expected_val_pairs()` but much nicer interface. See diff of this PR.

I will not port all tests from `parse_expected_val_pairs()` to `parse_expected_val_pairs2()` because it is a big amount work. The function should be used for new tests and if tests will be overworked.