### PR TITLE
implement filter rule for supported C++ standard support of Nvcc compiler versions

### DIFF
--- a/src/bashi/filter_compiler.py
+++ b/src/bashi/filter_compiler.py
@@ -290,7 +290,7 @@ def compiler_filter(
                 # Rule: c21
                 if compiler in row and row[compiler].name == GCC:
                     for gcc_cxx_ver in GCC_CXX_SUPPORT_VERSION:
-                        if row[compiler].version >= gcc_cxx_ver.gcc:
+                        if row[compiler].version >= gcc_cxx_ver.compiler:
                             if row[CXX_STANDARD].version > gcc_cxx_ver.cxx:
                                 reason(
                                     output,
@@ -304,7 +304,7 @@ def compiler_filter(
                     # handle case, if GCC version is older, than the oldest defined GCC C++ support
                     # entry
                     if (
-                        row[compiler].version < GCC_CXX_SUPPORT_VERSION[-1].gcc
+                        row[compiler].version < GCC_CXX_SUPPORT_VERSION[-1].compiler
                         and row[CXX_STANDARD].version >= GCC_CXX_SUPPORT_VERSION[-1].cxx
                     ):
                         reason(

--- a/src/bashi/result_modules/cxx_compiler_support.py
+++ b/src/bashi/result_modules/cxx_compiler_support.py
@@ -3,8 +3,65 @@
 from typing import List
 from bashi.types import ParameterValuePair
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from bashi.versions import GCC_CXX_SUPPORT_VERSION
+from bashi.versions import CompilerCxxSupport, GCC_CXX_SUPPORT_VERSION, CLANG_CXX_SUPPORT
 from bashi.utils import remove_parameter_value_pairs_ranges
+
+
+def _remove_unsupported_cxx_version_for_compiler(
+    parameter_value_pairs: List[ParameterValuePair],
+    removed_parameter_value_pairs: List[ParameterValuePair],
+    compiler_name: str,
+    compiler_cxx_support_list: List[CompilerCxxSupport],
+    compiler_type: str,
+):
+    """Remove unsupported combinations of compiler versions and C++ standard.
+
+    Args:
+
+    parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
+    removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
+    compiler_name (str): name of the compiler
+    compiler_cxx_support_list List[CompilerCxxSupport]: list containing which compiler version added
+        support for a new C++ standard
+    compiler_type: HOST_COMPILER or DEVICE_COMPILER
+    """
+    sorted_compiler_cxx_supported_version = sorted(compiler_cxx_support_list)
+    # loop over version ranges
+    # first iteration: handle all GCC version older then the oldest defined version
+    # n+1 iterations: handle versions between the defined supported GCC versions
+    # last iteration: handle all GCC versions younger than the latest defined GCC version
+    compiler_cxx_ver = sorted_compiler_cxx_supported_version[0]
+    compiler_min_ver: str = ANY_VERSION
+    cxx_min_ver: int = int(str(compiler_cxx_ver.cxx)) - 3
+
+    if cxx_min_ver < 11:
+        raise RuntimeError("Does not support minium C++ version older than 14.")
+
+    for i in range(len(sorted_compiler_cxx_supported_version) + 1):
+        if i < len(sorted_compiler_cxx_supported_version):
+            compiler_cxx_ver = sorted_compiler_cxx_supported_version[i]
+            compiler_max_ver: str = str(compiler_cxx_ver.compiler)
+        else:
+            compiler_max_ver = ANY_VERSION
+
+        remove_parameter_value_pairs_ranges(
+            parameter_value_pairs,
+            removed_parameter_value_pairs,
+            parameter1=compiler_type,
+            value_name1=compiler_name,
+            value_min_version1=compiler_min_ver,
+            value_max_version1=compiler_max_ver,
+            value_min_version1_inclusive=True,
+            value_max_version1_inclusive=False,
+            parameter2=CXX_STANDARD,
+            value_min_version2=cxx_min_ver,
+            value_min_version2_inclusive=False,
+            value_max_version2_inclusive=False,
+        )
+
+        if i < len(sorted_compiler_cxx_supported_version):
+            compiler_min_ver = str(compiler_cxx_ver.compiler)
+            cxx_min_ver = int(str(compiler_cxx_ver.cxx))
 
 
 def _remove_unsupported_cxx_versions_for_gcc(
@@ -18,41 +75,32 @@ def _remove_unsupported_cxx_versions_for_gcc(
     parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
     removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
     """
-    sorted_gcc_cxx_supported_version = sorted(GCC_CXX_SUPPORT_VERSION)
-    # loop over version ranges
-    # first iteration: handle all GCC version older then the oldest defined version
-    # n+1 iterations: handle versions between the defined supported GCC versions
-    # last iteration: handle all GCC versions younger than the latest defined GCC version
     for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-        gcc_cxx_ver = sorted_gcc_cxx_supported_version[0]
-        gcc_min_ver: str = ANY_VERSION
-        cxx_min_ver: int = int(str(gcc_cxx_ver.cxx)) - 3
+        _remove_unsupported_cxx_version_for_compiler(
+            parameter_value_pairs,
+            removed_parameter_value_pairs,
+            GCC,
+            GCC_CXX_SUPPORT_VERSION,
+            compiler_type,
+        )
 
-        if cxx_min_ver < 11:
-            raise RuntimeError("Does not support minium C++ version older than 11.")
 
-        for i in range(len(sorted_gcc_cxx_supported_version) + 1):
-            if i < len(sorted_gcc_cxx_supported_version):
-                gcc_cxx_ver = sorted_gcc_cxx_supported_version[i]
-                gcc_max_ver: str = str(gcc_cxx_ver.gcc)
-            else:
-                gcc_max_ver = ANY_VERSION
+def _remove_unsupported_cxx_versions_for_clang(
+    parameter_value_pairs: List[ParameterValuePair],
+    removed_parameter_value_pairs: List[ParameterValuePair],
+):
+    """Remove unsupported combinations of Clang compiler versions and C++ standard.
 
-            remove_parameter_value_pairs_ranges(
-                parameter_value_pairs,
-                removed_parameter_value_pairs,
-                parameter1=compiler_type,
-                value_name1=GCC,
-                value_min_version1=gcc_min_ver,
-                value_max_version1=gcc_max_ver,
-                value_min_version1_inclusive=True,
-                value_max_version1_inclusive=False,
-                parameter2=CXX_STANDARD,
-                value_min_version2=cxx_min_ver,
-                value_min_version2_inclusive=False,
-                value_max_version2_inclusive=False,
-            )
+    Args:
 
-            if i < len(sorted_gcc_cxx_supported_version):
-                gcc_min_ver = str(gcc_cxx_ver.gcc)
-                cxx_min_ver = int(str(gcc_cxx_ver.cxx))
+    parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
+    removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        _remove_unsupported_cxx_version_for_compiler(
+            parameter_value_pairs,
+            removed_parameter_value_pairs,
+            CLANG,
+            CLANG_CXX_SUPPORT,
+            compiler_type,
+        )

--- a/src/bashi/result_modules/cxx_compiler_support.py
+++ b/src/bashi/result_modules/cxx_compiler_support.py
@@ -3,7 +3,12 @@
 from typing import List
 from bashi.types import ParameterValuePair
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from bashi.versions import CompilerCxxSupport, GCC_CXX_SUPPORT_VERSION, CLANG_CXX_SUPPORT
+from bashi.versions import (
+    CompilerCxxSupport,
+    GCC_CXX_SUPPORT_VERSION,
+    CLANG_CXX_SUPPORT,
+    NVCC_CXX_SUPPORT_VERSION,
+)
 from bashi.utils import remove_parameter_value_pairs_ranges
 
 
@@ -104,3 +109,23 @@ def _remove_unsupported_cxx_versions_for_clang(
             CLANG_CXX_SUPPORT,
             compiler_type,
         )
+
+
+def _remove_unsupported_cxx_versions_for_nvcc(
+    parameter_value_pairs: List[ParameterValuePair],
+    removed_parameter_value_pairs: List[ParameterValuePair],
+):
+    """Remove unsupported combinations of Nvcc compiler versions and C++ standard.
+
+    Args:
+
+    parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
+    removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
+    """
+    _remove_unsupported_cxx_version_for_compiler(
+        parameter_value_pairs,
+        removed_parameter_value_pairs,
+        NVCC,
+        NVCC_CXX_SUPPORT_VERSION,
+        DEVICE_COMPILER,
+    )

--- a/src/bashi/result_modules/cxx_compiler_support.py
+++ b/src/bashi/result_modules/cxx_compiler_support.py
@@ -1,0 +1,58 @@
+"""Filter rules to remove compiler C++ standard combination, which are not supported."""
+
+from typing import List
+from bashi.types import ParameterValuePair
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.versions import GCC_CXX_SUPPORT_VERSION
+from bashi.utils import remove_parameter_value_pairs_ranges
+
+
+def _remove_unsupported_cxx_versions_for_gcc(
+    parameter_value_pairs: List[ParameterValuePair],
+    removed_parameter_value_pairs: List[ParameterValuePair],
+):
+    """Remove unsupported combinations of GCC compiler versions and C++ standard.
+
+    Args:
+
+    parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
+    removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
+    """
+    sorted_gcc_cxx_supported_version = sorted(GCC_CXX_SUPPORT_VERSION)
+    # loop over version ranges
+    # first iteration: handle all GCC version older then the oldest defined version
+    # n+1 iterations: handle versions between the defined supported GCC versions
+    # last iteration: handle all GCC versions younger than the latest defined GCC version
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        gcc_cxx_ver = sorted_gcc_cxx_supported_version[0]
+        gcc_min_ver: str = ANY_VERSION
+        cxx_min_ver: int = int(str(gcc_cxx_ver.cxx)) - 3
+
+        if cxx_min_ver < 11:
+            raise RuntimeError("Does not support minium C++ version older than 11.")
+
+        for i in range(len(sorted_gcc_cxx_supported_version) + 1):
+            if i < len(sorted_gcc_cxx_supported_version):
+                gcc_cxx_ver = sorted_gcc_cxx_supported_version[i]
+                gcc_max_ver: str = str(gcc_cxx_ver.gcc)
+            else:
+                gcc_max_ver = ANY_VERSION
+
+            remove_parameter_value_pairs_ranges(
+                parameter_value_pairs,
+                removed_parameter_value_pairs,
+                parameter1=compiler_type,
+                value_name1=GCC,
+                value_min_version1=gcc_min_ver,
+                value_max_version1=gcc_max_ver,
+                value_min_version1_inclusive=True,
+                value_max_version1_inclusive=False,
+                parameter2=CXX_STANDARD,
+                value_min_version2=cxx_min_ver,
+                value_min_version2_inclusive=False,
+                value_max_version2_inclusive=False,
+            )
+
+            if i < len(sorted_gcc_cxx_supported_version):
+                gcc_min_ver = str(gcc_cxx_ver.gcc)
+                cxx_min_ver = int(str(gcc_cxx_ver.cxx))

--- a/src/bashi/results.py
+++ b/src/bashi/results.py
@@ -21,7 +21,10 @@ from bashi.versions import (
 )
 
 # pyright: reportPrivateUsage=false
-from bashi.result_modules.cxx_compiler_support import _remove_unsupported_cxx_versions_for_gcc
+from bashi.result_modules.cxx_compiler_support import (
+    _remove_unsupported_cxx_versions_for_gcc,
+    _remove_unsupported_cxx_versions_for_nvcc,
+)
 
 
 @typechecked
@@ -87,6 +90,7 @@ def get_expected_bashi_parameter_value_pairs(
     )
     _remove_unsupported_cuda_versions_for_ubuntu(param_val_pair_list, removed_param_val_pair_list)
     _remove_unsupported_cxx_versions_for_gcc(param_val_pair_list, removed_param_val_pair_list)
+    _remove_unsupported_cxx_versions_for_nvcc(param_val_pair_list, removed_param_val_pair_list)
     return (param_val_pair_list, removed_param_val_pair_list)
 
 

--- a/src/bashi/results.py
+++ b/src/bashi/results.py
@@ -18,8 +18,10 @@ from bashi.versions import (
     CLANG_CUDA_MAX_CUDA_VERSION,
     NvccHostSupport,
     ClangCudaSDKSupport,
-    GCC_CXX_SUPPORT_VERSION,
 )
+
+# pyright: reportPrivateUsage=false
+from bashi.result_modules.cxx_compiler_support import _remove_unsupported_cxx_versions_for_gcc
 
 
 @typechecked
@@ -910,54 +912,3 @@ def _remove_unsupported_cuda_versions_for_ubuntu(
             value_max_version2=12,
             value_max_version2_inclusive=False,
         )
-
-
-def _remove_unsupported_cxx_versions_for_gcc(
-    parameter_value_pairs: List[ParameterValuePair],
-    removed_parameter_value_pairs: List[ParameterValuePair],
-):
-    """Remove unsupported combinations of GCC compiler versions and C++ standard.
-
-    Args:
-
-    parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
-    removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
-    """
-    sorted_gcc_cxx_supported_version = sorted(GCC_CXX_SUPPORT_VERSION)
-    # loop over version ranges
-    # first iteration: handle all GCC version older then the oldest defined version
-    # n+1 iterations: handle versions between the defined supported GCC versions
-    # last iteration: handle all GCC versions younger than the latest defined GCC version
-    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-        gcc_cxx_ver = sorted_gcc_cxx_supported_version[0]
-        gcc_min_ver: str = ANY_VERSION
-        cxx_min_ver: int = int(str(gcc_cxx_ver.cxx)) - 3
-
-        if cxx_min_ver < 11:
-            raise RuntimeError("Does not support minium C++ version older than 11.")
-
-        for i in range(len(sorted_gcc_cxx_supported_version) + 1):
-            if i < len(sorted_gcc_cxx_supported_version):
-                gcc_cxx_ver = sorted_gcc_cxx_supported_version[i]
-                gcc_max_ver: str = str(gcc_cxx_ver.gcc)
-            else:
-                gcc_max_ver = ANY_VERSION
-
-            remove_parameter_value_pairs_ranges(
-                parameter_value_pairs,
-                removed_parameter_value_pairs,
-                parameter1=compiler_type,
-                value_name1=GCC,
-                value_min_version1=gcc_min_ver,
-                value_max_version1=gcc_max_ver,
-                value_min_version1_inclusive=True,
-                value_max_version1_inclusive=False,
-                parameter2=CXX_STANDARD,
-                value_min_version2=cxx_min_ver,
-                value_min_version2_inclusive=False,
-                value_max_version2_inclusive=False,
-            )
-
-            if i < len(sorted_gcc_cxx_supported_version):
-                gcc_min_ver = str(gcc_cxx_ver.gcc)
-                cxx_min_ver = int(str(gcc_cxx_ver.cxx))

--- a/src/bashi/versions.py
+++ b/src/bashi/versions.py
@@ -65,20 +65,20 @@ class ClangCudaSDKSupport(VersionSupportBase):
 
 
 # pylint: disable=too-few-public-methods
-class GccCxxSupport(VersionSupportBase):
-    """Contains a gcc version and host compiler version. Does automatically parse the input strings
-    to package.version.Version.
+class CompilerCxxSupport(VersionSupportBase):
+    """Contains a compiler version and host compiler version. Does automatically parse the input
+    strings to package.version.Version.
 
     Provides comparision operators for sorting.
     """
 
     def __init__(self, gcc_version: str, cxx_version: str):
         VersionSupportBase.__init__(self, gcc_version, cxx_version)
-        self.gcc: packaging.version.Version = self.version1
+        self.compiler: packaging.version.Version = self.version1
         self.cxx: packaging.version.Version = self.version2
 
     def __str__(self) -> str:
-        return f"GCC {str(self.gcc)} + CXX {self.cxx}"
+        return f"compiler {str(self.compiler)} + CXX {self.cxx}"
 
 
 VERSIONS: Dict[str, List[Union[str, int, float]]] = {
@@ -175,12 +175,20 @@ CLANG_CUDA_MAX_CUDA_VERSION: List[ClangCudaSDKSupport] = [
 CLANG_CUDA_MAX_CUDA_VERSION.sort(reverse=True)
 
 # define the maximum supported cxx version for a specific gcc version
-GCC_CXX_SUPPORT_VERSION: List[GccCxxSupport] = [
-    GccCxxSupport("8", "17"),
-    GccCxxSupport("10", "20"),
-    GccCxxSupport("11", "23"),
+GCC_CXX_SUPPORT_VERSION: List[CompilerCxxSupport] = [
+    CompilerCxxSupport("8", "17"),
+    CompilerCxxSupport("10", "20"),
+    CompilerCxxSupport("11", "23"),
 ]
 GCC_CXX_SUPPORT_VERSION.sort(reverse=True)
+
+# define the maximum supported cxx version for a specific clang version
+CLANG_CXX_SUPPORT: List[CompilerCxxSupport] = [
+    CompilerCxxSupport("9", "17"),
+    CompilerCxxSupport("14", "20"),
+    CompilerCxxSupport("17", "23"),
+]
+CLANG_CXX_SUPPORT.sort(reverse=True)
 
 
 # pylint: disable=too-many-branches

--- a/src/bashi/versions.py
+++ b/src/bashi/versions.py
@@ -85,9 +85,6 @@ VERSIONS: Dict[str, List[Union[str, int, float]]] = {
     GCC: [8, 9, 10, 11, 12, 13],
     CLANG: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
     NVCC: [
-        10.0,
-        10.1,
-        10.2,
         11.0,
         11.1,
         11.2,
@@ -189,6 +186,14 @@ CLANG_CXX_SUPPORT: List[CompilerCxxSupport] = [
     CompilerCxxSupport("17", "23"),
 ]
 CLANG_CXX_SUPPORT.sort(reverse=True)
+
+# define the maximum supported cxx version for a specific nvcc version
+NVCC_CXX_SUPPORT_VERSION: List[CompilerCxxSupport] = [
+    CompilerCxxSupport("10.0", "14"),
+    CompilerCxxSupport("11.0", "17"),
+    CompilerCxxSupport("12.0", "20"),
+]
+NVCC_CXX_SUPPORT_VERSION.sort(reverse=True)
 
 
 # pylint: disable=too-many-branches

--- a/tests/result/test_compiler_support_cxx.py
+++ b/tests/result/test_compiler_support_cxx.py
@@ -3,12 +3,11 @@
 import unittest
 
 # pyright: reportPrivateUsage=false
-from bashi.result_modules.cxx_compiler_support import _remove_unsupported_cxx_version_for_compiler
-
-# pyright: reportPrivateUsage=false
 from bashi.result_modules.cxx_compiler_support import (
+    _remove_unsupported_cxx_version_for_compiler,
     _remove_unsupported_cxx_versions_for_gcc,
     _remove_unsupported_cxx_versions_for_clang,
+    _remove_unsupported_cxx_versions_for_nvcc,
 )
 from bashi.types import ParameterValuePair
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -203,6 +202,48 @@ class TestCompilerCXXSupportResultFilter(unittest.TestCase):
 
         default_remove_test(
             _remove_unsupported_cxx_versions_for_clang,
+            test_param_value_pairs,
+            expected_results,
+            self,
+        )
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_unsupported_cxx_versions_for_nvcc(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                ((DEVICE_COMPILER, NVCC, 10.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, NVCC, 10.1), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, NVCC, 10.2), (CXX_STANDARD, 20)),
+                ((DEVICE_COMPILER, NVCC, 11.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, NVCC, 11.8), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, NVCC, 11.2), (CXX_STANDARD, 20)),
+                ((DEVICE_COMPILER, NVCC, 11.8), (CXX_STANDARD, 23)),
+                ((DEVICE_COMPILER, NVCC, 12.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, NVCC, 12.8), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, NVCC, 12.2), (CXX_STANDARD, 20)),
+                ((DEVICE_COMPILER, NVCC, 12.8), (CXX_STANDARD, 23)),
+                ((DEVICE_COMPILER, NVCC, 99.8), (CXX_STANDARD, 20)),
+            ]
+        )
+
+        expected_results: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                ((DEVICE_COMPILER, NVCC, 10.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, NVCC, 11.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, NVCC, 11.8), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, NVCC, 12.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, NVCC, 12.8), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, NVCC, 12.2), (CXX_STANDARD, 20)),
+                ((DEVICE_COMPILER, NVCC, 99.8), (CXX_STANDARD, 20)),
+            ]
+        )
+
+        default_remove_test(
+            _remove_unsupported_cxx_versions_for_nvcc,
             test_param_value_pairs,
             expected_results,
             self,

--- a/tests/result/test_compiler_support_cxx.py
+++ b/tests/result/test_compiler_support_cxx.py
@@ -3,9 +3,16 @@
 import unittest
 
 # pyright: reportPrivateUsage=false
-from bashi.results import _remove_unsupported_cxx_versions_for_gcc
+from bashi.result_modules.cxx_compiler_support import _remove_unsupported_cxx_version_for_compiler
+
+# pyright: reportPrivateUsage=false
+from bashi.result_modules.cxx_compiler_support import (
+    _remove_unsupported_cxx_versions_for_gcc,
+    _remove_unsupported_cxx_versions_for_clang,
+)
 from bashi.types import ParameterValuePair
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.versions import CompilerCxxSupport
 from utils_test import (
     parse_expected_val_pairs2,
     default_remove_test,
@@ -14,6 +21,28 @@ from utils_test import (
 
 
 class TestCompilerCXXSupportResultFilter(unittest.TestCase):
+    def test_older_standard_than_cxx_11(self):
+        compiler_support_list = [
+            CompilerCxxSupport("8", "11"),
+            CompilerCxxSupport("9", "14"),
+        ]
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                ((HOST_COMPILER, GCC, 8), (CXX_STANDARD, 11)),
+                ((HOST_COMPILER, GCC, 9), (CXX_STANDARD, 14)),
+            ]
+        )
+        removed_param_value_pairs: List[ParameterValuePair] = []
+
+        with self.assertRaises(RuntimeError):
+            _remove_unsupported_cxx_version_for_compiler(
+                test_param_value_pairs,
+                removed_param_value_pairs,
+                GCC,
+                compiler_support_list,
+                HOST_COMPILER,
+            )
+
     def test_remove_unsupported_cxx_versions_for_gcc(self):
         test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs2(
             [
@@ -102,6 +131,78 @@ class TestCompilerCXXSupportResultFilter(unittest.TestCase):
 
         default_remove_test(
             _remove_unsupported_cxx_versions_for_gcc,
+            test_param_value_pairs,
+            expected_results,
+            self,
+        )
+        self.assertEqual(
+            test_param_value_pairs,
+            expected_results,
+            create_diff_parameter_value_pairs(test_param_value_pairs, expected_results),
+        )
+
+    def test_remove_unsupported_cxx_versions_for_clang(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                # corner cases
+                ((HOST_COMPILER, CLANG, 9), (CXX_STANDARD, 14)),
+                ((HOST_COMPILER, CLANG, 9), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 9), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, CLANG, 9), (CXX_STANDARD, 23)),
+                ((DEVICE_COMPILER, CLANG, 14), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, CLANG, 14), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, CLANG, 14), (CXX_STANDARD, 20)),
+                ((DEVICE_COMPILER, CLANG, 14), (CXX_STANDARD, 23)),
+                ((HOST_COMPILER, CLANG, 17), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 17), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, CLANG, 17), (CXX_STANDARD, 23)),
+                ((HOST_COMPILER, CLANG, 17), (CXX_STANDARD, 26)),
+                # between
+                ((HOST_COMPILER, CLANG, 12), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 12), (CXX_STANDARD, 19)),
+                ((HOST_COMPILER, CLANG, 13), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 13), (CXX_STANDARD, 20)),
+                # older than minumum specified GCC version
+                ((HOST_COMPILER, CLANG, 6), (CXX_STANDARD, 0)),
+                ((HOST_COMPILER, CLANG, 6), (CXX_STANDARD, 14)),
+                ((HOST_COMPILER, CLANG, 6), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 6), (CXX_STANDARD, 20)),
+                # newer than maximum specified GCC version
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 14)),
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 23)),
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 9999)),
+            ]
+        )
+
+        expected_results: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                # corner cases
+                ((HOST_COMPILER, CLANG, 9), (CXX_STANDARD, 14)),
+                ((HOST_COMPILER, CLANG, 9), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, CLANG, 14), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, CLANG, 14), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, CLANG, 14), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, CLANG, 17), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 17), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, CLANG, 17), (CXX_STANDARD, 23)),
+                # between
+                ((HOST_COMPILER, CLANG, 12), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 13), (CXX_STANDARD, 17)),
+                # older than minumum specified GCC version
+                ((HOST_COMPILER, CLANG, 6), (CXX_STANDARD, 0)),
+                ((HOST_COMPILER, CLANG, 6), (CXX_STANDARD, 14)),
+                # newer than maximum specified GCC version
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 14)),
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 17)),
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, CLANG, 9999), (CXX_STANDARD, 23)),
+            ]
+        )
+
+        default_remove_test(
+            _remove_unsupported_cxx_versions_for_clang,
             test_param_value_pairs,
             expected_results,
             self,

--- a/tests/test_compiler_cxx_support.py
+++ b/tests/test_compiler_cxx_support.py
@@ -194,6 +194,89 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
             self.assertFalse(compiler_filter_typechecked(row, reason_msg), f"{row}")
             self.assertEqual(
                 reason_msg.getvalue(),
-                f"{compiler_type} GCC {row[compiler_type].version} does not support "
+                f"{compiler_type} gcc {row[compiler_type].version} does not support "
+                f"C++{row[CXX_STANDARD].version}",
+            )
+
+    def test_valid_in_range_nvcc_cxx_support_c23(self):
+        for row in [
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 10.1)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 0)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 11.0)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 14)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 11.0)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 17)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 12.3)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 14)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 12.8)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 17)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 12.0)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 20)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 99.0)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 20)),
+                }
+            ),
+        ]:
+            self.assertTrue(compiler_filter_typechecked(row), f"{row}")
+
+    def test_invalid_in_range_nvcc_cxx_support_c23(self):
+        for row in [
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 10.2)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 9999)),
+                },
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 10.2)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 20)),
+                },
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 11.8)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 20)),
+                },
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((NVCC, 12.9)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 23)),
+                },
+            ),
+        ]:
+            reason_msg = io.StringIO()
+
+            self.assertFalse(compiler_filter_typechecked(row, reason_msg), f"{row}")
+            self.assertEqual(
+                reason_msg.getvalue(),
+                f"{DEVICE_COMPILER} nvcc {row[DEVICE_COMPILER].version} does not support "
                 f"C++{row[CXX_STANDARD].version}",
             )


### PR DESCRIPTION
fix #30 

Includes parts of PR #58. This PR needs to merged before #58, but #58 did some refactoring. Therefore overtake it changes.