### PR TITLE
implement filter rule for supported C++ standard support of ICPX compiler versions

### DIFF
--- a/src/bashi/filter_compiler.py
+++ b/src/bashi/filter_compiler.py
@@ -22,6 +22,7 @@ from bashi.versions import (
     CLANG_CUDA_CXX_SUPPORT_VERSION,
     NVCC_CXX_SUPPORT_VERSION,
     MAX_CUDA_SDK_CXX_SUPPORT,
+    ICPX_CXX_SUPPORT_VERSION,
 )
 from bashi.utils import reason
 
@@ -432,6 +433,13 @@ def compiler_filter(
                 # Rule: c25
                 if _remove_unsupported_compiler_cxx_combination(
                     row, CLANG_CUDA, compiler, CLANG_CUDA_CXX_SUPPORT_VERSION, output
+                ):
+                    # reason() is inside _remove_unsupported_compiler_cxx_combination
+                    return False
+
+                # Rule: c28
+                if _remove_unsupported_compiler_cxx_combination(
+                    row, ICPX, compiler, ICPX_CXX_SUPPORT_VERSION, output
                 ):
                     # reason() is inside _remove_unsupported_compiler_cxx_combination
                     return False

--- a/src/bashi/result_modules/cxx_compiler_support.py
+++ b/src/bashi/result_modules/cxx_compiler_support.py
@@ -12,6 +12,7 @@ from bashi.versions import (
     NVCC_CXX_SUPPORT_VERSION,
     CLANG_CUDA_CXX_SUPPORT_VERSION,
     MAX_CUDA_SDK_CXX_SUPPORT,
+    ICPX_CXX_SUPPORT_VERSION,
 )
 from bashi.utils import remove_parameter_value_pairs_ranges
 
@@ -253,3 +254,24 @@ def _remove_unsupported_cxx_versions_for_cuda(
         value_min_version2=list(cxx_bounds.keys())[-1],
         value_min_version2_inclusive=False,
     )
+
+
+def _remove_unsupported_cxx_versions_for_icpx(
+    parameter_value_pairs: List[ParameterValuePair],
+    removed_parameter_value_pairs: List[ParameterValuePair],
+):
+    """Remove unsupported combinations of ICPX compiler versions and C++ standard.
+
+    Args:
+
+    parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
+    removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        _remove_unsupported_cxx_version_for_compiler(
+            parameter_value_pairs,
+            removed_parameter_value_pairs,
+            ICPX,
+            ICPX_CXX_SUPPORT_VERSION,
+            compiler_type,
+        )

--- a/src/bashi/results.py
+++ b/src/bashi/results.py
@@ -27,6 +27,7 @@ from bashi.result_modules.cxx_compiler_support import (
     _remove_unsupported_cxx_versions_for_nvcc,
     _remove_unsupported_cxx_versions_for_clang_cuda,
     _remove_unsupported_cxx_versions_for_cuda,
+    _remove_unsupported_cxx_versions_for_icpx,
 )
 
 
@@ -99,6 +100,7 @@ def get_expected_bashi_parameter_value_pairs(
         param_val_pair_list, removed_param_val_pair_list
     )
     _remove_unsupported_cxx_versions_for_cuda(param_val_pair_list, removed_param_val_pair_list)
+    _remove_unsupported_cxx_versions_for_icpx(param_val_pair_list, removed_param_val_pair_list)
     return (param_val_pair_list, removed_param_val_pair_list)
 
 

--- a/tests/result/test_compiler_support_cxx.py
+++ b/tests/result/test_compiler_support_cxx.py
@@ -10,6 +10,7 @@ from bashi.result_modules.cxx_compiler_support import (
     _remove_unsupported_cxx_versions_for_nvcc,
     _remove_unsupported_cxx_versions_for_clang_cuda,
     _remove_unsupported_cxx_versions_for_cuda,
+    _remove_unsupported_cxx_versions_for_icpx,
 )
 from bashi.types import ParameterValuePair
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -357,3 +358,32 @@ class TestCompilerCXXSupportResultFilter(unittest.TestCase):
                 output += f"  {str(v)}\n"
             e.add_note(output)
             raise (e)
+
+    def test_remove_unsupported_cxx_versions_for_icpx(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                ((DEVICE_COMPILER, NVCC, 10.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 14)),
+                ((HOST_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 23)),
+                ((DEVICE_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 26)),
+            ]
+        )
+
+        expected_results: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                ((DEVICE_COMPILER, NVCC, 10.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 14)),
+                ((HOST_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 17)),
+                ((DEVICE_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, ICPX, "2025.0"), (CXX_STANDARD, 23)),
+            ]
+        )
+
+        default_remove_test(
+            _remove_unsupported_cxx_versions_for_icpx,
+            test_param_value_pairs,
+            expected_results,
+            self,
+        )

--- a/tests/test_compiler_cxx_support.py
+++ b/tests/test_compiler_cxx_support.py
@@ -892,3 +892,63 @@ class TestClangBasedCompilerCXXSupport(unittest.TestCase):
             f"\nresult: \n{new_line.join([str(x) for x in result])}"
             f"\nexpected: \n{new_line.join([str(x) for x in expected])}",
         )
+
+    def test_valid_icpx_supported_cxx_c27(self):
+        for row in [
+            OD(
+                {
+                    HOST_COMPILER: ppv((ICPX, "2025.0")),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 14)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((ICPX, "2025.0")),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 17)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((ICPX, "2025.0")),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 20)),
+                }
+            ),
+            OD(
+                {
+                    HOST_COMPILER: ppv((ICPX, "2025.0")),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 23)),
+                }
+            ),
+        ]:
+            self.assertTrue(compiler_filter_typechecked(row), f"{row}")
+
+    def test_invalid_icpx_supported_cxx_c27(self):
+        for row in [
+            OD(
+                {
+                    HOST_COMPILER: ppv((ICPX, "2025.0")),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 26)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((ICPX, "2025.0")),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 99)),
+                }
+            ),
+        ]:
+            if HOST_COMPILER in row:
+                compiler_type = HOST_COMPILER
+            elif DEVICE_COMPILER in row:
+                compiler_type = DEVICE_COMPILER
+            else:
+                compiler_type = ""
+
+            reason_msg = io.StringIO()
+
+            self.assertFalse(compiler_filter_typechecked(row, reason_msg), f"{row}")
+            self.assertEqual(
+                reason_msg.getvalue(),
+                f"{compiler_type} icpx {row[compiler_type].version} does not support "
+                f"C++{row[CXX_STANDARD].version}",
+            )

--- a/tests/test_compiler_cxx_support.py
+++ b/tests/test_compiler_cxx_support.py
@@ -12,6 +12,8 @@ from bashi.versions import (
     _get_clang_cuda_cuda_sdk_cxx_support,
     MAX_CUDA_SDK_CXX_SUPPORT,
     NVCC_CXX_SUPPORT_VERSION,
+    ClangBase,
+    _get_clang_base_compiler_cxx_support,
 )
 from bashi.filter_compiler import (
     compiler_filter_typechecked,
@@ -849,4 +851,44 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
             f"For the potential combination of C++-{max_clang_cuda_support_cxx.cxx} + "
             f"CUDA {invalid_cuda_sdk_version} there is no "
             f"Clang-CUDA compiler which support this.",
+        )
+
+
+class TestClangBasedCompilerCXXSupport(unittest.TestCase):
+    def test_get_clang_base_compiler_cxx_support(self):
+        clang_cxx_support_version: List[CompilerCxxSupport] = [
+            CompilerCxxSupport("9", "17"),
+            CompilerCxxSupport("14", "20"),
+            CompilerCxxSupport("17", "23"),
+        ]
+
+        given: List[ClangBase] = [
+            ClangBase("2017.1", "7"),
+            ClangBase("2018.1", "9"),
+            ClangBase("2019.3", "10"),
+            ClangBase("2020.0", "14"),
+            ClangBase("2021.0", "15"),
+            ClangBase("2025.0", "19"),
+        ]
+        expected: List[CompilerCxxSupport] = sorted(
+            [
+                CompilerCxxSupport("2017.1", "17"),
+                CompilerCxxSupport("2018.1", "17"),
+                CompilerCxxSupport("2019.3", "17"),
+                CompilerCxxSupport("2020.0", "20"),
+                CompilerCxxSupport("2021.0", "20"),
+                CompilerCxxSupport("2025.0", "23"),
+            ]
+        )
+
+        result = sorted(_get_clang_base_compiler_cxx_support(given, clang_cxx_support_version))
+
+        # workaround for Python <= 3.11
+        # SyntaxError: f-string expression part cannot include a backslash
+        new_line = "\n"
+        self.assertEqual(
+            result,
+            expected,
+            f"\nresult: \n{new_line.join([str(x) for x in result])}"
+            f"\nexpected: \n{new_line.join([str(x) for x in expected])}",
         )


### PR DESCRIPTION
fix #63 