### PR TITLE
implement filter rule for supported C++ standard support of HIPCC compiler versions

### DIFF
--- a/src/bashi/filter_compiler.py
+++ b/src/bashi/filter_compiler.py
@@ -23,6 +23,7 @@ from bashi.versions import (
     NVCC_CXX_SUPPORT_VERSION,
     MAX_CUDA_SDK_CXX_SUPPORT,
     ICPX_CXX_SUPPORT_VERSION,
+    HIPCC_CXX_SUPPORT_VERSION,
 )
 from bashi.utils import reason
 
@@ -440,6 +441,13 @@ def compiler_filter(
                 # Rule: c28
                 if _remove_unsupported_compiler_cxx_combination(
                     row, ICPX, compiler, ICPX_CXX_SUPPORT_VERSION, output
+                ):
+                    # reason() is inside _remove_unsupported_compiler_cxx_combination
+                    return False
+
+                # Rule: c29
+                if _remove_unsupported_compiler_cxx_combination(
+                    row, HIPCC, compiler, HIPCC_CXX_SUPPORT_VERSION, output
                 ):
                     # reason() is inside _remove_unsupported_compiler_cxx_combination
                     return False

--- a/src/bashi/result_modules/cxx_compiler_support.py
+++ b/src/bashi/result_modules/cxx_compiler_support.py
@@ -13,6 +13,7 @@ from bashi.versions import (
     CLANG_CUDA_CXX_SUPPORT_VERSION,
     MAX_CUDA_SDK_CXX_SUPPORT,
     ICPX_CXX_SUPPORT_VERSION,
+    HIPCC_CXX_SUPPORT_VERSION,
 )
 from bashi.utils import remove_parameter_value_pairs_ranges
 
@@ -273,5 +274,26 @@ def _remove_unsupported_cxx_versions_for_icpx(
             removed_parameter_value_pairs,
             ICPX,
             ICPX_CXX_SUPPORT_VERSION,
+            compiler_type,
+        )
+
+
+def _remove_unsupported_cxx_versions_for_hipcc(
+    parameter_value_pairs: List[ParameterValuePair],
+    removed_parameter_value_pairs: List[ParameterValuePair],
+):
+    """Remove unsupported combinations of HIPCC compiler versions and C++ standard.
+
+    Args:
+
+    parameter_value_pairs (List[ParameterValuePair]): List of parameter-value pairs.
+    removed_parameter_value_pairs (List[ParameterValuePair): list with removed parameter-value-pairs
+    """
+    for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+        _remove_unsupported_cxx_version_for_compiler(
+            parameter_value_pairs,
+            removed_parameter_value_pairs,
+            HIPCC,
+            HIPCC_CXX_SUPPORT_VERSION,
             compiler_type,
         )

--- a/src/bashi/results.py
+++ b/src/bashi/results.py
@@ -28,6 +28,7 @@ from bashi.result_modules.cxx_compiler_support import (
     _remove_unsupported_cxx_versions_for_clang_cuda,
     _remove_unsupported_cxx_versions_for_cuda,
     _remove_unsupported_cxx_versions_for_icpx,
+    _remove_unsupported_cxx_versions_for_hipcc,
 )
 
 
@@ -101,6 +102,7 @@ def get_expected_bashi_parameter_value_pairs(
     )
     _remove_unsupported_cxx_versions_for_cuda(param_val_pair_list, removed_param_val_pair_list)
     _remove_unsupported_cxx_versions_for_icpx(param_val_pair_list, removed_param_val_pair_list)
+    _remove_unsupported_cxx_versions_for_hipcc(param_val_pair_list, removed_param_val_pair_list)
     return (param_val_pair_list, removed_param_val_pair_list)
 
 

--- a/src/bashi/versions.py
+++ b/src/bashi/versions.py
@@ -182,7 +182,7 @@ VERSIONS: Dict[str, List[Union[str, int, float]]] = {
         12.5,
         12.6,
     ],
-    HIPCC: [5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 6.0, 6.1, 6.2],
+    HIPCC: [5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 6.0, 6.1, 6.2],
     ICPX: ["2025.0"],
     UBUNTU: [18.04, 20.04, 22.04, 24.04],
     CMAKE: [
@@ -321,6 +321,25 @@ ICPX_CLANG_VERSION: List[ClangBase] = [ClangBase("2025.0", "19")]
 
 ICPX_CXX_SUPPORT_VERSION: List[CompilerCxxSupport] = _get_clang_base_compiler_cxx_support(
     ICPX_CLANG_VERSION, CLANG_CXX_SUPPORT_VERSION
+)
+
+# This list stores which HIPCC version based on which Clang
+# The list allows to reuse the knowledge of Clang and apply it on HIPCC like the C++ standard
+# support.
+HIPCC_CLANG_VERSION: List[ClangBase] = [
+    ClangBase("5.1", "14"),
+    ClangBase("5.2", "14"),
+    ClangBase("5.3", "15"),
+    ClangBase("5.5", "16"),
+    ClangBase("5.6", "16"),
+    ClangBase("5.7", "17"),
+    ClangBase("6.0", "17"),
+    ClangBase("6.1", "17"),
+    ClangBase("6.2", "18"),
+]
+
+HIPCC_CXX_SUPPORT_VERSION: List[CompilerCxxSupport] = _get_clang_base_compiler_cxx_support(
+    HIPCC_CLANG_VERSION, CLANG_CXX_SUPPORT_VERSION
 )
 
 

--- a/tests/result/test_compiler_support_cxx.py
+++ b/tests/result/test_compiler_support_cxx.py
@@ -11,6 +11,7 @@ from bashi.result_modules.cxx_compiler_support import (
     _remove_unsupported_cxx_versions_for_clang_cuda,
     _remove_unsupported_cxx_versions_for_cuda,
     _remove_unsupported_cxx_versions_for_icpx,
+    _remove_unsupported_cxx_versions_for_hipcc,
 )
 from bashi.types import ParameterValuePair
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -383,6 +384,34 @@ class TestCompilerCXXSupportResultFilter(unittest.TestCase):
 
         default_remove_test(
             _remove_unsupported_cxx_versions_for_icpx,
+            test_param_value_pairs,
+            expected_results,
+            self,
+        )
+
+    def test_remove_unsupported_cxx_versions_for_hipcc(self):
+        test_param_value_pairs: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                ((DEVICE_COMPILER, NVCC, 10.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, HIPCC, 5.3), (CXX_STANDARD, 20)),
+                ((DEVICE_COMPILER, HIPCC, 5.3), (CXX_STANDARD, 23)),
+                ((HOST_COMPILER, HIPCC, 6.3), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, HIPCC, 6.3), (CXX_STANDARD, 23)),
+                ((HOST_COMPILER, HIPCC, 6.3), (CXX_STANDARD, 26)),
+            ]
+        )
+
+        expected_results: List[ParameterValuePair] = parse_expected_val_pairs2(
+            [
+                ((DEVICE_COMPILER, NVCC, 10.0), (CXX_STANDARD, 14)),
+                ((DEVICE_COMPILER, HIPCC, 5.3), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, HIPCC, 6.3), (CXX_STANDARD, 20)),
+                ((HOST_COMPILER, HIPCC, 6.3), (CXX_STANDARD, 23)),
+            ]
+        )
+
+        default_remove_test(
+            _remove_unsupported_cxx_versions_for_hipcc,
             test_param_value_pairs,
             expected_results,
             self,

--- a/tests/test_compiler_cxx_support.py
+++ b/tests/test_compiler_cxx_support.py
@@ -952,3 +952,63 @@ class TestClangBasedCompilerCXXSupport(unittest.TestCase):
                 f"{compiler_type} icpx {row[compiler_type].version} does not support "
                 f"C++{row[CXX_STANDARD].version}",
             )
+
+    def test_valid_hipcc_supported_cxx_c28(self):
+        for row in [
+            OD(
+                {
+                    HOST_COMPILER: ppv((HIPCC, 5.7)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 14)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((HIPCC, 6.0)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 17)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((HIPCC, 6.1)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 20)),
+                }
+            ),
+            OD(
+                {
+                    HOST_COMPILER: ppv((HIPCC, 5.7)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 23)),
+                }
+            ),
+        ]:
+            self.assertTrue(compiler_filter_typechecked(row), f"{row}")
+
+    def test_invalid_hipcc_supported_cxx_c28(self):
+        for row in [
+            OD(
+                {
+                    HOST_COMPILER: ppv((HIPCC, 6.3)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 26)),
+                }
+            ),
+            OD(
+                {
+                    DEVICE_COMPILER: ppv((HIPCC, 6.8)),
+                    CXX_STANDARD: ppv((CXX_STANDARD, 99)),
+                }
+            ),
+        ]:
+            if HOST_COMPILER in row:
+                compiler_type = HOST_COMPILER
+            elif DEVICE_COMPILER in row:
+                compiler_type = DEVICE_COMPILER
+            else:
+                compiler_type = ""
+
+            reason_msg = io.StringIO()
+
+            self.assertFalse(compiler_filter_typechecked(row, reason_msg), f"{row}")
+            self.assertEqual(
+                reason_msg.getvalue(),
+                f"{compiler_type} hipcc {row[compiler_type].version} does not support "
+                f"C++{row[CXX_STANDARD].version}",
+            )


### PR DESCRIPTION
fix #62 