### PR TITLE
Allow to use strings as value-version

### DIFF
--- a/example/src/example_filter.py
+++ b/example/src/example_filter.py
@@ -11,6 +11,7 @@ from bashi.versions import (
     NVCC_CLANG_MAX_VERSION,
     NVCC_CXX_SUPPORT_VERSION,
 )
+from .globals import BUILD_TYPE, CMAKE_RELEASE_VER
 
 
 class ExampleFilter(FilterBase):
@@ -189,4 +190,16 @@ class ExampleFilter(FilterBase):
                 for cpu_backend in cpu_backends:
                     if cpu_backend in row and row[cpu_backend].version == OFF_VER:
                         return False
+        if (
+            CMAKE in row
+            and row[CMAKE].version <= pkv.parse("3.25")
+            and BUILD_TYPE in row
+            and row[BUILD_TYPE].version == CMAKE_RELEASE_VER
+        ):
+            self.reason(
+                "CMake 3.25 does not support CMake Release builds."
+                "Only for demonstration. In reality it is working."
+            )
+            return False
+
         return True

--- a/example/src/globals.py
+++ b/example/src/globals.py
@@ -1,0 +1,35 @@
+from typing import Dict
+import packaging.version
+from bashi import Parameter, ValueName, ValueVersion
+
+# CMake build type
+BUILD_TYPE: Parameter = "build_type"
+CMAKE_RELEASE: str = "0"
+CMAKE_DEBUG: str = "1"
+CMAKE_RELEASE_VER: ValueVersion = packaging.version.parse(CMAKE_RELEASE)
+CMAKE_DEBUG_VER: ValueVersion = packaging.version.parse(CMAKE_DEBUG)
+BUILD_TYPES_NAMES = {
+    "Release": CMAKE_RELEASE_VER,
+    "Debug": CMAKE_DEBUG_VER,
+}
+
+
+def get_version_aliases() -> Dict[ValueName, Dict[ValueVersion, str]]:
+    """Returns a dict, which contains alias strings for specific value-versions of a specific
+    parameter-value.
+
+    Internal bashi works only with version numbers. Therefore if we want to use an string as
+    value-version, we need to map the string to a version.
+
+    Returns:
+        Dict[ValueName, Dict[ValueVersion, str]]: string aliases for value-versions of
+            parameter-values
+    """
+    version_aliases: Dict[ValueName, Dict[ValueVersion, str]] = {}
+    for val_name, version_map in [(BUILD_TYPE, BUILD_TYPES_NAMES)]:
+        version_map_parsed: Dict[ValueVersion, str] = {}
+        for alias, ver in version_map.items():
+            version_map_parsed[ver] = alias
+        version_aliases[val_name] = version_map_parsed
+
+    return version_aliases

--- a/example/validate.py
+++ b/example/validate.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 import bashiValidate
 from src.example_filter import ExampleFilter
+from src.globals import BUILD_TYPE, CMAKE_RELEASE, CMAKE_DEBUG, BUILD_TYPES_NAMES
 
 
 def main(args: List[str], silent: bool) -> bool:
@@ -18,8 +19,12 @@ def main(args: List[str], silent: bool) -> bool:
     """
     # setting args and silent are only required for the unit tests
     validator = bashiValidate.Validator(args=args, silent=silent)
-    validator.add_software_version_parameter(name="SoftwareA", help_text="SoftwareA version number")
+    validator.add_software_version_parameter(
+        name="SoftwareA", help_text="SoftwareA version number", short_name="SoftA"
+    )
+    validator.add_string_parameter(BUILD_TYPE, "CMake Build Type", BUILD_TYPES_NAMES, "buildType")
     validator.add_known_version(name="SoftwareA", versions=["1.0", "2.0", "2.1"])
+    validator.add_known_version(name=BUILD_TYPE, versions=[CMAKE_RELEASE, CMAKE_DEBUG])
     validator.add_custom_filter(ExampleFilter())
     return validator.validate()
 

--- a/src/bashi/__init__.py
+++ b/src/bashi/__init__.py
@@ -1,0 +1,14 @@
+"""The bashi module."""
+
+from bashi.types import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.versions import get_parameter_value_matrix
+from bashi.generator import get_runtime_infos, generate_combination_list
+from bashi.utils import (
+    print_row_nice,
+    add_print_row_nice_parameter_alias,
+    add_print_row_nice_version_alias,
+    check_parameter_value_pair_in_combination_list,
+    check_unexpected_parameter_value_pair_in_combination_list,
+)
+from bashi.filter import FilterBase
+from bashi.results import get_expected_bashi_parameter_value_pairs

--- a/src/bashi/utils.py
+++ b/src/bashi/utils.py
@@ -285,6 +285,33 @@ def reason(output: Optional[IO[str]], msg: str):
         )
 
 
+print_row_nice_parameter_alias: Dict[Parameter, str] = PARAMETER_SHORT_NAME.copy()
+print_row_nice_version_aliases: Dict[ValueName, Dict[ValueVersion, str]] = {}
+
+
+def add_print_row_nice_parameter_alias(parameter_name: Parameter, alias: str):
+    """Add an alias for an parameter, which will be displayed if print_row_nice() is called.
+
+    Args:
+        parameter_name (Parameter): parameter
+        alias (str): alias
+    """
+    print_row_nice_parameter_alias[parameter_name] = alias
+
+
+def add_print_row_nice_version_alias(
+    value_name: ValueName, versions_aliases: Dict[ValueVersion, str]
+):
+    """Add an aliases for the version of parameter-value, which will be displayed if
+    print_row_nice() is called.
+
+    Args:
+        value_name (ValueName): parameter-name
+        versions_aliases (Dict[ValueVersion, str]): text which is display instead the value-version
+    """
+    print_row_nice_version_aliases[value_name] = versions_aliases
+
+
 # do not cover code, because the function is only used for debugging
 def print_row_nice(
     row: ParameterValueTuple, init: str = "", bashi_validate: bool = False
@@ -308,15 +335,19 @@ def print_row_nice(
         parameter_prefix = "" if not bashi_validate else "--"
         if param in [HOST_COMPILER, DEVICE_COMPILER]:
             s += (
-                f"{parameter_prefix}{PARAMETER_SHORT_NAME.get(param, param)}="
-                f"{PARAMETER_SHORT_NAME.get(val.name, val.name)}@"
+                f"{parameter_prefix}{print_row_nice_parameter_alias.get(param, param)}="
+                f"{print_row_nice_parameter_alias.get(val.name, val.name)}@"
                 f"{nice_version.get(val.version, str(val.version))} "
             )
         else:
-            s += (
-                f"{parameter_prefix}{PARAMETER_SHORT_NAME.get(param, param)}="
-                f"{nice_version.get(val.version, str(val.version))} "
-            )
+            s += f"{parameter_prefix}{print_row_nice_parameter_alias.get(param, param)}="
+            if (
+                val.name in print_row_nice_version_aliases
+                and val.version in print_row_nice_version_aliases[val.name]
+            ):
+                s += f"{print_row_nice_version_aliases[val.name][val.version]} "
+            else:
+                s += f"{nice_version.get(val.version, str(val.version))} "
     print(s)
 
 

--- a/src/bashi/versions.py
+++ b/src/bashi/versions.py
@@ -203,7 +203,6 @@ VERSIONS: Dict[str, List[Union[str, int, float]]] = {
     ICPX: ["2025.0"],
     UBUNTU: [18.04, 20.04, 22.04, 24.04],
     CMAKE: [
-        3.18,
         3.19,
         3.20,
         3.21,

--- a/tests/test_supported_version.py
+++ b/tests/test_supported_version.py
@@ -78,7 +78,7 @@ class TestParameterValueGenerator(unittest.TestCase):
 
     def test_software_versions(self):
         for name, version in [
-            (CMAKE, 3.18),
+            (CMAKE, 3.19),
             (CMAKE, 3.21),
             (BOOST, "1.80.0"),
             (UBUNTU, "20.04"),


### PR DESCRIPTION
Bashi uses only `packaging.version.Version` objects for values-versions. But sometimes, a version number for value-version of a parameter-value does not makes sense, e.g. the CMake build type.

We can use `row[BUILD_TYPE].version == CMAKE_RELESE_VER` in a filter function. `CMAKE_RELEASE_VER` is mapped to a fake version (`CMAKE_RELEASE_VER=packaging.version.parse("0")`. The PR implements two features to improve the usage.

1. `print_row_nice()` can display a version string instead the fake version number: `build_type=Release` instead `build_type=0`
2. The validator accepts a string as argument value instead the version number: `bashi-validate --build_type=Release` instead `bashi-validate --build_type=0`  