### PR TITLE
relaxe version check for CMake

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -314,13 +314,14 @@ def verify(
         value_max_version2_inclusive=True,
     )
 
-    return (
-        check_parameter_value_pair_in_combination_list(combination_list, expected_param_val_tuple)
-        and check_unexpected_parameter_value_pair_in_combination_list(
-            combination_list, unexpected_param_val_tuple
-        )
-        and all_right
+    expected_param_val_okay = check_parameter_value_pair_in_combination_list(
+        combination_list, expected_param_val_tuple
     )
+    unexpected_param_val_okay = check_unexpected_parameter_value_pair_in_combination_list(
+        combination_list, unexpected_param_val_tuple
+    )
+
+    return expected_param_val_okay and unexpected_param_val_okay and all_right
 
 
 def create_yaml(combination_list: CombinationList):

--- a/src/bashi/versions.py
+++ b/src/bashi/versions.py
@@ -550,7 +550,12 @@ def is_supported_version(name: ValueName, version: ValueVersion) -> bool:
             local_versions[backend_name] = [OFF, ON]
 
     for ver in local_versions[name]:
-        if pkv.parse(str(ver)) == version:
+        parsed_version = pkv.parse(str(ver))
+        # in case of CMAKE, we don't care about the patch level
+        if name == CMAKE:
+            parsed_version = pkv.parse(f"{parsed_version.major}.{parsed_version.minor}")
+            version = pkv.parse(f"{version.major}.{version.minor}")
+        if parsed_version == version:
             return True
 
     return False


### PR DESCRIPTION
Fix also a bug in verify function, which does not display unexpected pairs, if expected pairs are missing.