### PR TITLE
add BashiRow

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,7 +4,8 @@
 
 ```python
 # filters all parameter-value-tuples where the host and device compiler do not have the same name
-def example_filter(row : ParameterValueTuple) -> bool:
+# bashiRow implements the parameter-value-tuple
+def example_filter(row : BashiRow) -> bool:
     if (HOST_COMPILER and row
         and DEVICE_COMPILER in row
         and row[HOST_COMPILER].name != row[DEVICE].name):

--- a/example/src/example_filter.py
+++ b/example/src/example_filter.py
@@ -2,11 +2,10 @@
 
 from typing import Dict, Callable, IO
 import packaging.version as pkv
-from bashi.types import ParameterValueTuple
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter import FilterBase
 from bashi.version.dependencies.nvcc import NvccHostSupport
-from bashi import VersionRelation
+from bashi import VersionRelation, BashiRow
 
 from .globals import BUILD_TYPE, CMAKE_RELEASE_VER
 
@@ -28,12 +27,12 @@ class ExampleFilter(FilterBase):
     # pylint: disable=too-many-locals
     def __call__(
         self,
-        row: ParameterValueTuple,
+        row: BashiRow,
     ) -> bool:
         """Check if given parameter-value-tuple is valid
 
         Args:
-            row (ParameterValueTuple): parameter-value-tuple to verify.
+            row (BashiRow): parameter-value-tuple to verify.
 
         Returns:
             bool: True, if parameter-value-tuple is valid.

--- a/example/src/example_filter.py
+++ b/example/src/example_filter.py
@@ -55,63 +55,54 @@ class ExampleFilter(FilterBase):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
             if compiler_type in row and row[compiler_type].name in gpu_compilers:
                 for cpu_backend in cpu_backends:
-                    if cpu_backend in row and row[cpu_backend].version == ON_VER:
+                    if row[cpu_backend].version == ON_VER:
                         self.reason(
                             f"Enabled CPU backend {cpu_backend} and GPU {compiler_type} "
                             f"{row[compiler_type].name} cannot used together."
                         )
                         return False
 
-        if DEVICE_COMPILER in row:
-            for cpu_compiler in cpu_compilers:
-                if row[DEVICE_COMPILER].name == cpu_compiler:
-                    for cpu_backend in cpu_backends:
-                        if cpu_backend in row and row[cpu_backend].version == OFF_VER:
-                            self.reason(
-                                f"The backend {cpu_backend} cannot be disabled if device compiler "
-                                f"{cpu_compiler} is used"
-                            )
-                            return False
-                    for gpu_backend in gpu_backends:
-                        if gpu_backend in row and row[gpu_backend].version != OFF_VER:
-                            self.reason(
-                                f"The backend {gpu_backend} cannot be enabled if device compiler "
-                                f"{cpu_compiler} is used"
-                            )
-                            return False
+        for cpu_compiler in cpu_compilers:
+            if row[DEVICE_COMPILER].name == cpu_compiler:
+                for cpu_backend in cpu_backends:
+                    if row[cpu_backend].version == OFF_VER:
+                        self.reason(
+                            f"The backend {cpu_backend} cannot be disabled if device compiler "
+                            f"{cpu_compiler} is used"
+                        )
+                        return False
+                for gpu_backend in gpu_backends:
+                    if row[gpu_backend].version != OFF_VER:
+                        self.reason(
+                            f"The backend {gpu_backend} cannot be enabled if device compiler "
+                            f"{cpu_compiler} is used"
+                        )
+                        return False
 
         # pylint: disable=too-many-nested-blocks
         if HOST_COMPILER in row and row[HOST_COMPILER].name in (GCC, CLANG):
-            if ALPAKA_ACC_GPU_CUDA_ENABLE in row:
-                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == OFF_VER:
-                    for cpu_backend in cpu_backends:
-                        if cpu_backend in row and row[cpu_backend].version == OFF_VER:
-                            self.reason(
-                                "If the host compiler is {row[HOST_COMPILER].name} and "
-                                "the CUDA backend is disable, all CPU backends needs to be enabled."
-                                f" {cpu_backend} is disabled."
-                            )
-                            return False
-                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == ON_VER:
-                    for cpu_backend in cpu_backends:
-                        if cpu_backend in row and row[cpu_backend].version == ON_VER:
-                            self.reason(
-                                "If the host compiler is {row[HOST_COMPILER].name} and "
-                                "the CUDA backend is disable, all CPU backends needs to be enabled."
-                                f" {cpu_backend} is enabled."
-                            )
-                            return False
-
-            if (
-                CXX_STANDARD in row
-                and not ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                and not (
-                    DEVICE_COMPILER in row
-                    or (DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC)
-                )
-            ):
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == OFF_VER:
                 for cpu_backend in cpu_backends:
-                    if cpu_backend in row and row[cpu_backend].version == OFF_VER:
+                    if row[cpu_backend].version == OFF_VER:
+                        self.reason(
+                            "If the host compiler is {row[HOST_COMPILER].name} and "
+                            "the CUDA backend is disable, all CPU backends needs to be enabled."
+                            f" {cpu_backend} is disabled."
+                        )
+                        return False
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == ON_VER:
+                for cpu_backend in cpu_backends:
+                    if row[cpu_backend].version == ON_VER:
+                        self.reason(
+                            "If the host compiler is {row[HOST_COMPILER].name} and "
+                            "the CUDA backend is disable, all CPU backends needs to be enabled."
+                            f" {cpu_backend} is enabled."
+                        )
+                        return False
+
+            if not ALPAKA_ACC_GPU_CUDA_ENABLE in row and not row[DEVICE_COMPILER].name == NVCC:
+                for cpu_backend in cpu_backends:
+                    if row[cpu_backend].version == OFF_VER:
                         nvcc_host_compiler_max_version: List[NvccHostSupport] = []
                         if row[HOST_COMPILER].name == GCC:
                             nvcc_host_compiler_max_version = sorted(
@@ -142,17 +133,17 @@ class ExampleFilter(FilterBase):
                             return False
 
         for cpu_backend in cpu_backends:
-            if cpu_backend in row and row[cpu_backend].version == ON_VER:
+            if row[cpu_backend].version == ON_VER:
                 for cpu_backend2 in cpu_backends:
                     if cpu_backend != cpu_backend2:
-                        if cpu_backend2 in row and row[cpu_backend2].version == OFF_VER:
+                        if row[cpu_backend2].version == OFF_VER:
                             self.reason(
                                 f"All CPU backends needs to be enabled. {cpu_backend} is "
                                 f"enabled, therefore {cpu_backend2} needs to be enabled too."
                             )
                             return False
                 for gpu_backend in gpu_backends:
-                    if gpu_backend in row and row[gpu_backend].version != OFF_VER:
+                    if row[gpu_backend].version != OFF_VER:
                         self.reason(
                             "If a single CPU backend is enabled all other gpu backends needs to be "
                             "disabled."
@@ -168,13 +159,9 @@ class ExampleFilter(FilterBase):
             # the specific Ubuntu version
             if HOST_COMPILER in row and row[HOST_COMPILER].name in (GCC, CLANG):
                 for cpu_backend in cpu_backends:
-                    if (
-                        cpu_backend in row
-                        and row[cpu_backend].version == OFF_VER
-                        and not self.runtime_infos[RT_AVAILABLE_CUDA_SDK_UBUNTU_VER](
-                            row[UBUNTU].version
-                        )
-                    ):
+                    if row[cpu_backend].version == OFF_VER and not self.runtime_infos[
+                        RT_AVAILABLE_CUDA_SDK_UBUNTU_VER
+                    ](row[UBUNTU].version):
                         return False
 
         # if nvcc does not support a gcc/clang version, the gcc/clang compiler can be only used as
@@ -183,20 +170,13 @@ class ExampleFilter(FilterBase):
             (GCC, max(comb.host for comb in self.version.get_nvcc_gcc_max_version())),
             (CLANG, max(comb.host for comb in self.version.get_nvcc_clang_max_version())),
         ):
-            if (
-                HOST_COMPILER in row
-                and row[HOST_COMPILER].name == compiler_name
-                and row[HOST_COMPILER].version > pkv.parse(str(max_supported_version))
+            if row[HOST_COMPILER].name == compiler_name and row[HOST_COMPILER].version > pkv.parse(
+                str(max_supported_version)
             ):
                 for cpu_backend in cpu_backends:
-                    if cpu_backend in row and row[cpu_backend].version == OFF_VER:
+                    if row[cpu_backend].version == OFF_VER:
                         return False
-        if (
-            CMAKE in row
-            and row[CMAKE].version <= pkv.parse("3.25")
-            and BUILD_TYPE in row
-            and row[BUILD_TYPE].version == CMAKE_RELEASE_VER
-        ):
+        if row[CMAKE].version <= pkv.parse("3.25") and row[BUILD_TYPE].version == CMAKE_RELEASE_VER:
             self.reason(
                 "CMake 3.25 does not support CMake Release builds."
                 "Only for demonstration. In reality it is working."

--- a/src/bashi/__init__.py
+++ b/src/bashi/__init__.py
@@ -24,3 +24,4 @@ from bashi.printer import (
 )
 from bashi.filter import FilterBase
 from bashi.results import get_expected_bashi_parameter_value_pairs
+from bashi.row import BashiRow

--- a/src/bashi/filter.py
+++ b/src/bashi/filter.py
@@ -1,8 +1,8 @@
 """Base class for filter functors."""
 
 from typing import Dict, Callable, Optional, IO
-from bashi.types import ParameterValueTuple
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class FilterBase:
@@ -52,11 +52,11 @@ class FilterBase:
                 end="",
             )
 
-    def __call__(self, _row: ParameterValueTuple) -> bool:
+    def __call__(self, _row: BashiRow) -> bool:
         """Implement the filter rules
 
         Args:
-            _row (ParameterValueTuple): parameter-value-tuple
+            _row (BashiRow): parameter-value-tuple
 
         Returns:
             bool: Return True if parameter-value-tuple passes the filter, otherwise false

--- a/src/bashi/filter_backend.py
+++ b/src/bashi/filter_backend.py
@@ -11,9 +11,9 @@ from typing import Dict, Optional, IO, Callable
 import packaging.version as pkv
 from typeguard import typechecked
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from bashi.types import ParameterValueTuple
 from bashi.version.relation import VersionRelation
 from bashi.filter import FilterBase
+from bashi.row import BashiRow
 
 
 # pylint: disable=too-many-branches
@@ -33,12 +33,12 @@ class BackendFilter(FilterBase):
 
     def __call__(
         self,
-        row: ParameterValueTuple,
+        row: BashiRow,
     ) -> bool:
         """Check if given parameter-value-tuple is valid
 
         Args:
-            row (ParameterValueTuple): parameter-value-tuple to verify.
+            row (BashiRow): parameter-value-tuple to verify.
 
         Returns:
             bool: True, if parameter-value-tuple is valid.
@@ -237,7 +237,7 @@ class BackendFilter(FilterBase):
 
 @typechecked
 def backend_filter_typechecked(
-    row: ParameterValueTuple,
+    row: BashiRow,
     version_relation: VersionRelation,
     output: Optional[IO[str]] = None,
 ) -> bool:

--- a/src/bashi/filter_backend.py
+++ b/src/bashi/filter_backend.py
@@ -44,80 +44,68 @@ class BackendFilter(FilterBase):
             bool: True, if parameter-value-tuple is valid.
         """
 
-        if ALPAKA_ACC_GPU_HIP_ENABLE in row and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
+        if row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
             # Rule: b1
             # related to rule c9
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-                if compiler_type in row and row[compiler_type].name != HIPCC:
+                if row[compiler_type].name != HIPCC:
                     self.reason("An enabled HIP backend requires hipcc as compiler.")
                     return False
 
             # Rule: b2
             # related to rule c10
             for one_api_backend in ONE_API_BACKENDS:
-                if one_api_backend in row and row[one_api_backend].version != OFF_VER:
+                if row[one_api_backend].version != OFF_VER:
                     self.reason("The HIP and SYCL backend cannot be enabled on the same time.")
                     return False
 
             # Rule: b3
             # related to rule c11
-            if (
-                ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-            ):
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                 self.reason("The HIP and CUDA backend cannot be enabled on the same time.")
                 return False
 
         for one_api_backend in ONE_API_BACKENDS:
-            if one_api_backend in row and row[one_api_backend].version != OFF_VER:
+            if row[one_api_backend].version != OFF_VER:
                 # Rule: b4
                 # related to rule c12
                 for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-                    if compiler_type in row and row[compiler_type].name != ICPX:
+                    if row[compiler_type].name != ICPX:
                         self.reason("An enabled SYCL backend requires icpx as compiler.")
                         return False
 
                 # Rule: b5
                 # related to rule c13
-                if (
-                    ALPAKA_ACC_GPU_HIP_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
                     self.reason("The SYCL and HIP backend cannot be enabled on the same time.")
                     return False
 
                 # Rule: b6
                 # related to rule c14
-                if (
-                    ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                     self.reason("The SYCL and CUDA backend cannot be enabled on the same time.")
                     return False
 
                 # Rule: b18
                 for other_one_api_backends in set(ONE_API_BACKENDS) - set([one_api_backend]):
-                    if (
-                        other_one_api_backends in row
-                        and row[other_one_api_backends].version != OFF_VER
-                    ):
+                    if row[other_one_api_backends].version != OFF_VER:
                         self.reason("Only one SYCL backend can be enabled.")
                         return False
 
-        if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == OFF_VER:
+        if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == OFF_VER:
             # Rule: b7
-            if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
+            if row[DEVICE_COMPILER].name == NVCC:
                 self.reason("CUDA backend needs to be enabled for nvcc")
                 return False
 
             # Rule: b16
             # related to rule c15
             for compiler in (HOST_COMPILER, DEVICE_COMPILER):
-                if compiler in row and row[compiler].name == CLANG_CUDA:
+                if row[compiler].name == CLANG_CUDA:
                     self.reason(f"CUDA backend needs to be enabled for {compiler} clang-cuda")
                     return False
 
-        if ALPAKA_ACC_GPU_CUDA_ENABLE in row and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
+        if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
             # Rule: b8
             # related to rule c2
             if HOST_COMPILER in row and row[HOST_COMPILER].name in (
@@ -131,14 +119,13 @@ class BackendFilter(FilterBase):
             # Rule: b9
             # related to rule c15
             if (
-                DEVICE_COMPILER in row
-                and row[DEVICE_COMPILER].name == NVCC
+                row[DEVICE_COMPILER].name == NVCC
                 and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != row[DEVICE_COMPILER].version
             ):
                 self.reason("CUDA backend and nvcc needs to have the same version")
                 return False
 
-            if HOST_COMPILER in row and row[HOST_COMPILER].name == GCC:
+            if row[HOST_COMPILER].name == GCC:
                 # Rule: b10
                 # related to rule c5
                 # remove all unsupported cuda sdk gcc version combinations
@@ -161,7 +148,7 @@ class BackendFilter(FilterBase):
                                 return False
                             break
 
-            if HOST_COMPILER in row and row[HOST_COMPILER].name == CLANG:
+            if row[HOST_COMPILER].name == CLANG:
                 # Rule: b11
                 # related to rule c8
                 if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version >= pkv.parse("11.3") and row[
@@ -195,24 +182,21 @@ class BackendFilter(FilterBase):
 
             # Rule: b14
             # related to rule c30
-            if (
-                ALPAKA_ACC_GPU_HIP_ENABLE in row
-                and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER
-            ):
+            if row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
                 self.reason("The CUDA and HIP backend cannot be enabled on the same time.")
                 return False
 
             # Rule: b15
             # related to rule c17
             for one_api_backend in ONE_API_BACKENDS:
-                if one_api_backend in row and row[one_api_backend].version != OFF_VER:
+                if row[one_api_backend].version != OFF_VER:
                     self.reason("The CUDA and SYCL backend cannot be enabled on the same time.")
                     return False
 
             # Rule: b17
             # related to rule c16
             for compiler in (HOST_COMPILER, DEVICE_COMPILER):
-                if compiler in row and row[compiler].name == CLANG_CUDA:
+                if row[compiler].name == CLANG_CUDA:
                     # if a clang-cuda version is newer than the latest known clang-cuda version,
                     # we needs to assume that it supports every CUDA SDK version
                     if (

--- a/src/bashi/filter_chain.py
+++ b/src/bashi/filter_chain.py
@@ -2,8 +2,8 @@
 
 from typing import Callable, Dict
 from typeguard import typechecked
+import covertable  # type: ignore
 import termcolor
-from bashi.types import ParameterValueTuple
 from bashi.globals import FilterDebugMode
 
 from bashi.filter import FilterBase
@@ -12,6 +12,7 @@ from bashi.filter_backend import BackendFilter
 from bashi.filter_software_dependency import SoftwareDependencyFilter
 from bashi.version.relation import VersionRelation
 from bashi.printer import get_str_row_nice
+from bashi.row import BashiRow
 
 
 # pylint: disable=too-few-public-methods
@@ -57,12 +58,14 @@ class FilterChain:
             self.custom_filter.runtime_infos = runtime_infos
         self.debug_print = debug_print
 
-    def __call__(self, row: ParameterValueTuple) -> bool:
+    def __call__(self, row: covertable.main.Row) -> bool:
+        bashi_row = BashiRow(row)
+
         result = (
-            self.compiler_filter(row)
-            and self.backend_filter(row)
-            and self.software_dependency_filter(row)
-            and self.custom_filter(row)
+            self.compiler_filter(bashi_row)
+            and self.backend_filter(bashi_row)
+            and self.software_dependency_filter(bashi_row)
+            and self.custom_filter(bashi_row)
         )
 
         if self.debug_print != FilterDebugMode.OFF:
@@ -100,12 +103,12 @@ def get_default_filter_chain(
                 constructed depending on the input parameter-value-matrix. The functions are named
                 by a string, takes an arbitrary number of arguments and return if the combination of
                 the given parameter-values are valid. Defaults to None.
-        custom_filter_function (FilterFunction): This functor is added as the last filter level and
+        custom_filter_function (FilterChain): This functor is added as the last filter level and
                 allows the user to add custom filter rules without having to create the entire
                 filter chain from scratch. Defaults to FilterBase().
 
     Returns:
-        FilterFunction: The filter function chain, which can be directly used in bashi.FilterAdapter
+        FilterChain: The filter function chain, which can be directly used in bashi.FilterAdapter
     """
 
     return FilterChain(

--- a/src/bashi/filter_compiler.py
+++ b/src/bashi/filter_compiler.py
@@ -176,7 +176,7 @@ class CompilerFilter(FilterBase):
         # library
         # it is not possible to add NVCC as HOST_COMPILER and filter out afterwards
         # this rule is only used by bashi-verify
-        if HOST_COMPILER in row and row[HOST_COMPILER].name == NVCC:
+        if row[HOST_COMPILER].name == NVCC:
             self.reason("nvcc is not allowed as host compiler")
             return False
 
@@ -202,8 +202,8 @@ class CompilerFilter(FilterBase):
 
         # now idea, how remove nested blocks without hitting the performance
         # pylint: disable=too-many-nested-blocks
-        if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
-            if HOST_COMPILER in row and row[HOST_COMPILER].name == GCC:
+        if row[DEVICE_COMPILER].name == NVCC:
+            if row[HOST_COMPILER].name == GCC:
                 # Rule: c5
                 # related to rule b10
                 # remove all unsupported nvcc gcc version combinations
@@ -223,7 +223,7 @@ class CompilerFilter(FilterBase):
                                 return False
                             break
 
-            if HOST_COMPILER in row and row[HOST_COMPILER].name == CLANG:
+            if row[HOST_COMPILER].name == CLANG:
                 # Rule: c7
                 # related to rule b11
                 if row[DEVICE_COMPILER].version >= pkv.parse("11.3") and row[
@@ -258,26 +258,20 @@ class CompilerFilter(FilterBase):
 
             # Rule: c15
             # related to rule b9
-            if (
-                ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != row[DEVICE_COMPILER].version
-            ):
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != row[DEVICE_COMPILER].version:
                 self.reason("nvcc and CUDA backend needs to have the same version")
                 return False
 
             # Rule: c16
             # related to rule b14
-            if (
-                ALPAKA_ACC_GPU_HIP_ENABLE in row
-                and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER
-            ):
+            if row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
                 self.reason("nvcc does not support the HIP backend.")
                 return False
 
             # Rule: c17
             # related to rule b15
             for one_api_backend in ONE_API_BACKENDS:
-                if one_api_backend in row and row[one_api_backend].version != OFF_VER:
+                if row[one_api_backend].version != OFF_VER:
                     self.reason("nvcc does not support the SYCL backend.")
                     return False
 
@@ -289,38 +283,28 @@ class CompilerFilter(FilterBase):
         # it is not possible to add the clang-cuda versions and filter it out afterwards
         # this rule is only used by bashi-verify
         for compiler in (HOST_COMPILER, DEVICE_COMPILER):
-            if (
-                compiler in row
-                and row[compiler].name == CLANG_CUDA
-                and row[compiler].version < pkv.parse("14")
-            ):
+            if row[compiler].name == CLANG_CUDA and row[compiler].version < pkv.parse("14"):
                 self.reason("all clang versions older than 14 are disabled as CUDA Compiler")
                 return False
 
         for compiler in (HOST_COMPILER, DEVICE_COMPILER):
-            if compiler in row and row[compiler].name == HIPCC:
+            if row[compiler].name == HIPCC:
                 # Rule: c9
                 # related to rule b1
-                if (
-                    ALPAKA_ACC_GPU_HIP_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_HIP_ENABLE].version == OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_HIP_ENABLE].version == OFF_VER:
                     self.reason("hipcc requires an enabled HIP backend.")
                     return False
 
                 # Rule: c10
                 # related to rule b2
                 for one_api_backend in ONE_API_BACKENDS:
-                    if one_api_backend in row and row[one_api_backend].version != OFF_VER:
+                    if row[one_api_backend].version != OFF_VER:
                         self.reason("hipcc does not support the SYCL backend.")
                         return False
 
                 # Rule: c11
                 # related to rule b2
-                if (
-                    ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                     self.reason("hipcc does not support the CUDA backend.")
                     return False
 
@@ -328,44 +312,31 @@ class CompilerFilter(FilterBase):
                 # Rule: c12
                 # related to rule b4
                 if all(
-                    one_api_backend in row and row[one_api_backend].version == OFF_VER
-                    for one_api_backend in ONE_API_BACKENDS
+                    row[one_api_backend].version == OFF_VER for one_api_backend in ONE_API_BACKENDS
                 ):
                     self.reason("icpx requires an enabled SYCL backend.")
                     return False
 
                 # Rule: c13
                 # related to rule b5
-                if (
-                    ALPAKA_ACC_GPU_HIP_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
                     self.reason("icpx does not support the HIP backend.")
                     return False
 
                 # Rule: c14
                 # related to rule b6
-                if (
-                    ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                     self.reason("icpx does not support the CUDA backend.")
                     return False
 
-            if compiler in row and row[compiler].name == CLANG_CUDA:
+            if row[compiler].name == CLANG_CUDA:
                 # Rule: c15
                 # related to rule b16
-                if (
-                    ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version == OFF_VER:
                     self.reason("clang-cuda requires an enabled CUDA backend.")
                     return False
 
-                if (
-                    ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                     # Rule: c16
                     # related to rule b17
                     # if a clang-cuda version is newer than the latest known clang-cuda version,
@@ -391,17 +362,14 @@ class CompilerFilter(FilterBase):
 
                 # Rule: c30
                 # related to rule b14
-                if (
-                    ALPAKA_ACC_GPU_HIP_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
                     self.reason("clang-cuda does not support the HIP backend.")
                     return False
 
                 # Rule: c18
                 # related to rule b15
                 for one_api_backend in ONE_API_BACKENDS:
-                    if one_api_backend in row and row[one_api_backend].version != OFF_VER:
+                    if row[one_api_backend].version != OFF_VER:
                         self.reason("clang-cuda does not support the SYCL backend.")
                         return False
 
@@ -468,10 +436,7 @@ class CompilerFilter(FilterBase):
                     # reason() is inside _remove_unsupported_compiler_cxx_combination
                     return False
 
-                if (
-                    ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-                ):
+                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                     # Rule: c26
                     # With the given CUDA backend version we can restrict the possible C++ standard
                     # already. If there is no Nvcc or Clang-CUDA version which supports the given
@@ -524,7 +489,7 @@ class CompilerFilter(FilterBase):
                     # Clang, the device compiler must be Nvcc.
                     # In this case, we know that the CUDA SDK and Nvcc has the same version number
                     # and therefore we can determine which is the maximum supported C++ standard.
-                    if HOST_COMPILER in row and row[HOST_COMPILER].name in (GCC, CLANG):
+                    if row[HOST_COMPILER].name in (GCC, CLANG):
                         if _remove_unsupported_compiler_cxx_combination(
                             row,
                             ALPAKA_ACC_GPU_CUDA_ENABLE,

--- a/src/bashi/filter_compiler.py
+++ b/src/bashi/filter_compiler.py
@@ -7,19 +7,20 @@ These identifiers are used in the test names, for example, to make it clear whic
 which rule.
 """
 
-from typing import Dict, Optional, IO, List, Callable
+from typing import Dict, Optional, IO, List, Callable, cast
 import packaging.version as pkv
 from typeguard import typechecked
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from bashi.types import ParameterValueTuple, Parameter, ValueName
+from bashi.types import Parameter, ValueName
 from bashi.version.dependencies.base_version_support import CompilerCxxSupport
 from bashi.version.relation import VersionRelation
 from bashi.filter import FilterBase
 from bashi.utils import reason
+from bashi.row import BashiRow
 
 
 def _remove_unsupported_compiler_cxx_combination(
-    row: ParameterValueTuple,
+    row: BashiRow,
     compiler_name: ValueName,
     compiler_type: Parameter,
     compiler_cxx_list: List[CompilerCxxSupport],
@@ -30,7 +31,7 @@ def _remove_unsupported_compiler_cxx_combination(
     Attention: Because of performance reasons, does not check if CXX_STANDARD is in the row.
 
     Args:
-        row (ParameterValueTuple): current row with parameter value
+        row (BashiRow): current row with parameter value
         compiler_name (ValueName): name of the compiler
         compiler_type (Parameter): HOST_COMPILER or DEVICE_COMPILER
         compiler_cxx_list (List[CompilerCxxSupport]): list containing which compiler version added
@@ -158,12 +159,12 @@ class CompilerFilter(FilterBase):
 
     def __call__(
         self,
-        row: ParameterValueTuple,
+        row: BashiRow,
     ) -> bool:
         """Check if given parameter-value-tuple is valid
 
         Args:
-            row (ParameterValueTuple): parameter-value-tuple to verify.
+            row (BashiRow): parameter-value-tuple to verify.
 
         Returns:
             bool: True, if parameter-value-tuple is valid.
@@ -477,7 +478,7 @@ class CompilerFilter(FilterBase):
                     # C++ standard with the given CUDA SDK, we can return false before the host or
                     # device compiler was added to the row.
                     if row[CXX_STANDARD].version > _get_max_supported_cxx_version_for_cuda_sdk(
-                        row[ALPAKA_ACC_GPU_CUDA_ENABLE].version,
+                        cast(ValueVersion, row[ALPAKA_ACC_GPU_CUDA_ENABLE].version),
                         self.version.get_nvcc_cxx_support_version(),
                         self.version.get_max_cuda_sdk_cxx_support(),
                     ):
@@ -500,12 +501,12 @@ class CompilerFilter(FilterBase):
                     if row[
                         CXX_STANDARD
                     ].version > _get_max_supported_cxx_version_for_cuda_sdk_for_nvcc(
-                        row[ALPAKA_ACC_GPU_CUDA_ENABLE].version,
+                        cast(ValueVersion, row[ALPAKA_ACC_GPU_CUDA_ENABLE].version),
                         self.version.get_nvcc_cxx_support_version(),
                     ) and row[
                         CXX_STANDARD
                     ].version <= _get_max_supported_cxx_version_for_cuda_sdk_for_clang_cuda(
-                        row[ALPAKA_ACC_GPU_CUDA_ENABLE].version,
+                        cast(ValueVersion, row[ALPAKA_ACC_GPU_CUDA_ENABLE].version),
                         self.version.get_max_cuda_sdk_cxx_support(),
                     ):
                         if (
@@ -544,7 +545,7 @@ class CompilerFilter(FilterBase):
 
 @typechecked
 def compiler_filter_typechecked(
-    row: ParameterValueTuple,
+    row: BashiRow,
     version_relation: VersionRelation,
     output: Optional[IO[str]] = None,
 ) -> bool:

--- a/src/bashi/filter_software_dependency.py
+++ b/src/bashi/filter_software_dependency.py
@@ -64,9 +64,9 @@ class SoftwareDependencyFilter(FilterBase):
         # Rule: d1
         # GCC 6 and older is not available in Ubuntu 20.04 and newer
 
-        if UBUNTU in row and row[UBUNTU].version >= pkv.parse("20.04"):
+        if row[UBUNTU].version >= pkv.parse("20.04"):
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-                if compiler_type in row and row[compiler_type].name == GCC:
+                if row[compiler_type].name == GCC:
                     if row[compiler_type].version <= pkv.parse("6"):
                         self.reason(
                             f"{_pretty_name_compiler(compiler_type)} GCC "
@@ -78,9 +78,9 @@ class SoftwareDependencyFilter(FilterBase):
         # Rule: d2
         # CMAKE 3.19 and older is not available with clang-cuda as device and host compiler
 
-        if CMAKE in row and row[CMAKE].version <= pkv.parse("3.18"):
+        if row[CMAKE].version <= pkv.parse("3.18"):
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-                if compiler_type in row and row[compiler_type].name == CLANG_CUDA:
+                if row[compiler_type].name == CLANG_CUDA:
                     self.reason(
                         f"{_pretty_name_compiler(compiler_type)} CLANG_CUDA "
                         "is not available in CMAKE "
@@ -92,7 +92,7 @@ class SoftwareDependencyFilter(FilterBase):
             # Rule: d3
             # check if a hipcc version is available on an ubuntu version
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-                if compiler_type in row and row[compiler_type].name == HIPCC:
+                if row[compiler_type].name == HIPCC:
                     for ubuntu_hip_range in self.version.get_ubuntu_hip_version_range():
                         if (
                             cast(ValueVersion, row[compiler_type].version)
@@ -107,10 +107,7 @@ class SoftwareDependencyFilter(FilterBase):
                             return False
 
             # Rule: d5
-            if (
-                ALPAKA_ACC_GPU_HIP_ENABLE in row
-                and row[ALPAKA_ACC_GPU_HIP_ENABLE].version == ON_VER
-            ):
+            if row[ALPAKA_ACC_GPU_HIP_ENABLE].version == ON_VER:
                 if RT_AVAILABLE_HIP_SDK_UBUNTU_VER in self.runtime_infos and not self.runtime_infos[
                     RT_AVAILABLE_HIP_SDK_UBUNTU_VER
                 ](row[UBUNTU].version):
@@ -121,7 +118,7 @@ class SoftwareDependencyFilter(FilterBase):
                     return False
 
             # Rule: d6
-            if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
+            if row[DEVICE_COMPILER].name == NVCC:
                 for ubuntu_cuda_range in self.version.get_ubuntu_cuda_version_range():
                     if (
                         cast(ValueVersion, row[DEVICE_COMPILER].version)
@@ -136,10 +133,7 @@ class SoftwareDependencyFilter(FilterBase):
                         return False
 
             # Rule: d7
-            if (
-                ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-            ):
+            if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                 for ubuntu_cuda_range in self.version.get_ubuntu_cuda_version_range():
                     if (
                         cast(ValueVersion, row[ALPAKA_ACC_GPU_CUDA_ENABLE].version)
@@ -155,7 +149,7 @@ class SoftwareDependencyFilter(FilterBase):
 
             # Rule: d8
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-                if compiler_type in row and row[compiler_type].name == CLANG_CUDA:
+                if row[compiler_type].name == CLANG_CUDA:
                     if row[UBUNTU].version not in self.version.get_ubuntu_clang_cuda_sdk_support():
                         self.reason(
                             "There is no installable CUDA SDK available for "
@@ -185,7 +179,7 @@ class SoftwareDependencyFilter(FilterBase):
                 # The case would be, that no Nvcc version and no Clang-CUDA version which supports
                 # the backend.
                 for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-                    if compiler_type in row and row[compiler_type].name == CLANG_CUDA:
+                    if row[compiler_type].name == CLANG_CUDA:
                         self.reason(
                             "There is no CUDA SDK in input parameter-value-matrix for "
                             f"{compiler_type} Clang-CUDA {row[compiler_type].version} which can be "
@@ -193,11 +187,7 @@ class SoftwareDependencyFilter(FilterBase):
                         )
                         return False
                 # Rule: d10
-                if (
-                    ALPAKA_ACC_GPU_CUDA_ENABLE in row
-                    and row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER
-                ):
-
+                if row[ALPAKA_ACC_GPU_CUDA_ENABLE].version != OFF_VER:
                     self.reason(
                         "There is no CUDA SDK for the CUDA backend "
                         f"{row[ALPAKA_ACC_GPU_CUDA_ENABLE].version} in the input "
@@ -206,7 +196,7 @@ class SoftwareDependencyFilter(FilterBase):
                     )
                     return False
                 # Rule: d11
-                if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
+                if row[DEVICE_COMPILER].name == NVCC:
                     self.reason(
                         "There is no CUDA SDK in input parameter-value-matrix for Nvcc "
                         f"{row[DEVICE_COMPILER].version} which can be installed on Ubuntu "

--- a/src/bashi/filter_software_dependency.py
+++ b/src/bashi/filter_software_dependency.py
@@ -7,14 +7,14 @@ These identifiers are used in the test names, for example, to make it clear whic
 which rule.
 """
 
-from typing import Dict, Optional, IO, Callable
+from typing import Dict, Optional, IO, Callable, cast
 import packaging.version as pkv
 from typeguard import typechecked
-from bashi.types import ParameterValueTuple
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter import FilterBase
 from bashi.version.relation import VersionRelation
 from bashi.printer import ubuntu_version_to_string
+from bashi.row import BashiRow
 
 
 def _pretty_name_compiler(constant: str) -> str:
@@ -47,12 +47,12 @@ class SoftwareDependencyFilter(FilterBase):
 
     def __call__(
         self,
-        row: ParameterValueTuple,
+        row: BashiRow,
     ) -> bool:
         """Check if given parameter-value-tuple is valid.
 
         Args:
-            row (ParameterValueTuple): parameter-value-tuple to verify.
+            row (BashiRow): parameter-value-tuple to verify.
 
         Returns:
             bool: True, if parameter-value-tuple is valid.
@@ -95,7 +95,8 @@ class SoftwareDependencyFilter(FilterBase):
                 if compiler_type in row and row[compiler_type].name == HIPCC:
                     for ubuntu_hip_range in self.version.get_ubuntu_hip_version_range():
                         if (
-                            row[compiler_type].version in ubuntu_hip_range.sdk_range
+                            cast(ValueVersion, row[compiler_type].version)
+                            in ubuntu_hip_range.sdk_range
                             and row[UBUNTU].version != ubuntu_hip_range.ubuntu
                         ):
                             self.reason(
@@ -123,7 +124,8 @@ class SoftwareDependencyFilter(FilterBase):
             if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
                 for ubuntu_cuda_range in self.version.get_ubuntu_cuda_version_range():
                     if (
-                        row[DEVICE_COMPILER].version in ubuntu_cuda_range.sdk_range
+                        cast(ValueVersion, row[DEVICE_COMPILER].version)
+                        in ubuntu_cuda_range.sdk_range
                         and row[UBUNTU].version != ubuntu_cuda_range.ubuntu
                     ):
                         self.reason(
@@ -140,7 +142,8 @@ class SoftwareDependencyFilter(FilterBase):
             ):
                 for ubuntu_cuda_range in self.version.get_ubuntu_cuda_version_range():
                     if (
-                        row[ALPAKA_ACC_GPU_CUDA_ENABLE].version in ubuntu_cuda_range.sdk_range
+                        cast(ValueVersion, row[ALPAKA_ACC_GPU_CUDA_ENABLE].version)
+                        in ubuntu_cuda_range.sdk_range
                         and row[UBUNTU].version != ubuntu_cuda_range.ubuntu
                     ):
                         self.reason(
@@ -161,8 +164,10 @@ class SoftwareDependencyFilter(FilterBase):
                         return False
 
                     if (
-                        row[compiler_type].version
-                        not in self.version.get_ubuntu_clang_cuda_sdk_support()[row[UBUNTU].version]
+                        cast(ValueVersion, row[compiler_type].version)
+                        not in self.version.get_ubuntu_clang_cuda_sdk_support()[
+                            cast(ValueVersion, row[UBUNTU].version)
+                        ]
                     ):
                         self.reason(
                             "There is no compatible CUDA SDK for Clang-CUDA "
@@ -213,7 +218,7 @@ class SoftwareDependencyFilter(FilterBase):
 
 @typechecked
 def software_dependency_filter_typechecked(
-    row: ParameterValueTuple,
+    row: BashiRow,
     version_relation: VersionRelation,
     output: Optional[IO[str]] = None,
 ) -> bool:

--- a/src/bashi/generator.py
+++ b/src/bashi/generator.py
@@ -82,7 +82,7 @@ def generate_combination_list(
         version_relation (VersionRelation): Provides information about the relationships between
                 the versions of various parameter-values. For example, which GCC version supports
                 which C++ standard.
-        custom_filter (FilterFunction, optional): Custom filter function to extend bashi
+        custom_filter (FilterBase, optional): Custom filter function to extend bashi
             filters. Defaults is lambda _: True.
         debug_print (FilterDebugMode): Depending on the debug mode, print additional information
             for each row passing the filter function. Defaults to FilterDebugMode.OFF.

--- a/src/bashi/printer.py
+++ b/src/bashi/printer.py
@@ -5,12 +5,11 @@ from bashi.types import (
     Parameter,
     ParameterValue,
     ParameterValueSingle,
-    ParameterValueTuple,
     ValueName,
     ValueVersion,
 )
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
-
+from bashi.row import BashiRow, NonExistingEntry
 
 # short names for parameter
 PARAMETER_SHORT_NAME: dict[Parameter, str] = {
@@ -105,12 +104,12 @@ def get_str_parameter_value_single(
 
 
 def get_str_row_nice(
-    row: ParameterValueTuple, init: str = "", bashi_validate: bool = False
+    row: BashiRow, init: str = "", bashi_validate: bool = False
 ) -> str:  # pragma: no cover
     """Returns a parameter-value-tuple as string in a short and nice way.
 
     Args:
-        row (ParameterValueTuple): row with parameter-value-tuple
+        row (BashiRow): row with parameter-value-tuple
         init (str, optional): Prefix of the output string. Defaults to "".
         bashi_validate (bool): If it is set to True, the row is printed in a form that can be passed
             directly as arguments to bashi-validate. Defaults to False.
@@ -126,13 +125,11 @@ def get_str_row_nice(
     return s
 
 
-def print_row_nice(
-    row: ParameterValueTuple, init: str = "", bashi_validate: bool = False
-):  # pragma: no cover
+def print_row_nice(row: BashiRow, init: str = "", bashi_validate: bool = False):  # pragma: no cover
     """Prints a parameter-value-tuple in a short and nice way.
 
     Args:
-        row (ParameterValueTuple): row with parameter-value-tuple
+        row (BashiRow): row with parameter-value-tuple
         init (str, optional): Prefix of the output string. Defaults to "".
         bashi_validate (bool): If it is set to True, the row is printed in a form that can be passed
             directly as arguments to bashi-validate. Defaults to False.
@@ -140,7 +137,7 @@ def print_row_nice(
     print(get_str_row_nice(row, init, bashi_validate))
 
 
-def ubuntu_version_to_string(version: ValueVersion) -> str:
+def ubuntu_version_to_string(version: ValueVersion | NonExistingEntry) -> str:
     """Returns the Ubuntu version representation correctly. Ubuntu versions
     use a leading 0 in their version scheme for months before October. pkv.parse()`
     parses e.g. the 04 from 20.04 to 4. Therefore the string representation of
@@ -153,6 +150,8 @@ def ubuntu_version_to_string(version: ValueVersion) -> str:
     Returns:
         str: string representation of the Ubuntu version
     """
+    if isinstance(version, NonExistingEntry):
+        return "NonExistingVersionEntry"
     return f"{version.major}.{version.minor:02}"
 
 

--- a/src/bashi/row.py
+++ b/src/bashi/row.py
@@ -1,0 +1,64 @@
+"""Row object for a bashi filter rule. See BashiRow class documentation."""
+
+import covertable  # type: ignore
+from bashi.types import ParameterValue
+
+
+class NonExistingEntry:
+    """A comparision with this object will return all the time false. That's the same result as a
+    key does not exist in a dict."""
+
+    def __lt__(self, _):
+        return False
+
+    def __le__(self, _):
+        return False
+
+    def __eq__(self, _):
+        return False
+
+    def __ne__(self, _):
+        return False
+
+    def __gt__(self, _):
+        return False
+
+    def __ge__(self, _):
+        return False
+
+
+# pylint: disable=too-few-public-methods
+class NonExistingParameterValue:
+    """Dummy interface object for a ParameterValue. Is used, if a parameter does not exist in a
+    row."""
+
+    def __init__(self) -> None:
+        self.name = NonExistingEntry()
+        self.version = NonExistingEntry()
+
+
+class BashiRow(covertable.main.Row):
+    """BashiRow provides the same interface as a `dict` or `OrderDict`, with one exception:
+    if the access operator attempts to access a non-existent key, a dummy object is returned instead
+    a error is thrown. The dummy object implements the `ParameterValue` interface and returns
+    `false` whenever the member variables `name` and `version` are compared with another object.
+
+    This eliminates the need to check whether a key exists in a filter rule:
+
+    `if HOST_COMPILER in row and row[HOST_COMPILER].name == NVCC:`
+
+    can be reduced to:
+
+    `if row[HOST_COMPILER].name == NVCC:`
+    """
+
+    def __init__(self, row):
+        if isinstance(row, covertable.main.Row):
+            super().__init__(row, row.factors, row.serials, row.pre_filter)
+        else:
+            super().__init__(row, None, None, None)
+
+    def __getitem__(self, item) -> ParameterValue | NonExistingParameterValue:
+        if super().__contains__(item):
+            return super().__getitem__(item)
+        return NonExistingParameterValue()

--- a/src/bashi/types.py
+++ b/src/bashi/types.py
@@ -1,6 +1,6 @@
 """bashi data types"""
 
-from typing import TypeAlias, List, Callable, NamedTuple, Tuple, Union
+from typing import TypeAlias, List, NamedTuple, Tuple, Union
 from collections import OrderedDict
 from packaging.version import Version
 
@@ -20,9 +20,6 @@ ParameterValuePair = NamedTuple(
 ParameterValueTuple: TypeAlias = OrderedDict[Parameter, ParameterValue]
 Combination: TypeAlias = OrderedDict[Parameter, ParameterValue]
 CombinationList: TypeAlias = List[Combination]
-
-# function signature of a filter function
-FilterFunction: TypeAlias = Callable[[ParameterValueTuple], bool]
 
 ParsableValueVersion: TypeAlias = Union[str, int, float, Version]
 

--- a/src/bashiValidate/validator.py
+++ b/src/bashiValidate/validator.py
@@ -4,10 +4,9 @@ import io
 import sys
 from typing import Dict, List, Callable
 import termcolor
-from collections import OrderedDict
 import packaging.version
 from typeguard import typechecked
-from bashi.types import ParameterValue, ParameterValueTuple
+from bashi.types import ParameterValue
 from bashi.version.utils import is_supported_version
 from bashi.filter import FilterBase
 from bashi.filter_compiler import CompilerFilter
@@ -18,6 +17,7 @@ from bashi.version import VERSIONS
 from bashi.version.utils import get_parameter_value_matrix
 from bashi.version.relation import VersionRelation
 from bashi.generator import get_runtime_infos
+from bashi.row import BashiRow
 from .arguments import get_validator_args, ArgumentAlias, VersionCheck, AliasParser
 
 
@@ -162,14 +162,14 @@ class Validator:
     def _check_single_filter(
         self,
         filter_func: FilterBase,
-        row: ParameterValueTuple,
+        row: BashiRow,
     ) -> bool:
         """Check if row passes a filter function.
 
         Args:
-            filter_func (Callable[[ParameterValueTuple, Optional[IO[str]]], bool]): The filter
+            filter_func (Callable[[BashiRow, Optional[IO[str]]], bool]): The filter
                 function
-            row (ParameterValueTuple): row with parameter-value-tuples
+            row (BashiRow): row with parameter-value-tuples
             required_parameter (List[str]): list of parameters, which will be used in the filter
                 rule
 
@@ -191,11 +191,11 @@ class Validator:
         return False
 
     @typechecked
-    def _check_filter_chain(self, row: ParameterValueTuple) -> bool:
+    def _check_filter_chain(self, row: BashiRow) -> bool:
         """Test a row with the bashi default filter chain.
 
         Args:
-            row (ParameterValueTuple): row to test
+            row (BashiRow): row to test
 
         Returns:
             bool: True if row passes all filters
@@ -211,11 +211,11 @@ class Validator:
 
         return all_true == len(self.filter_stages)
 
-    def get_row(self) -> ParameterValueTuple:
+    def get_row(self) -> BashiRow:
         """Generate parameter-value-tuple from the application arguments.
 
         Returns:
-            ParameterValueTuple: parameter-value-tuple
+            BashiRow: parameter-value-tuple
         """
         args = self.parser.parse_args(args=self.args)
 
@@ -234,7 +234,7 @@ class Validator:
         for filter_stage in self.filter_stages:
             filter_stage.runtime_infos = self.runtime_infos
 
-        row: ParameterValueTuple = OrderedDict()
+        row = BashiRow({})
 
         # Add parameter-values in the order in which they are passed via arguments
         for param_arg in self.param_order:

--- a/tests/test_bashi_row.py
+++ b/tests/test_bashi_row.py
@@ -1,0 +1,95 @@
+# pylint: disable=missing-docstring
+import unittest
+import operator
+import packaging
+
+from utils_test import parse_param_val as ppv
+from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from bashi.row import NonExistingEntry, NonExistingParameterValue, BashiRow
+
+
+class TestBashiRow(unittest.TestCase):
+    def test_comparision_non_existing_entry(self):
+        non_existing_entry = NonExistingEntry()
+        for logical_op in (
+            operator.lt,
+            operator.le,
+            operator.eq,
+            operator.ne,
+            operator.gt,
+            operator.ge,
+        ):
+            self.assertFalse(logical_op(non_existing_entry, "HIPCC"))
+            self.assertFalse(logical_op(non_existing_entry, packaging.version.parse("3.0")))
+
+    def test_comparision_non_existing_parameter_value(self):
+        non_existing_parameter_value = NonExistingParameterValue()
+        for logical_op in (
+            operator.lt,
+            operator.le,
+            operator.eq,
+            operator.ne,
+            operator.gt,
+            operator.ge,
+        ):
+            self.assertFalse(logical_op(non_existing_parameter_value.name, "HIPCC"))
+            self.assertFalse(
+                logical_op(non_existing_parameter_value.version, packaging.version.parse("3.0"))
+            )
+
+    def test_bashi_row_object(self):
+        row = BashiRow({HOST_COMPILER: ppv((GCC, 13)), CMAKE: ppv((CMAKE, "3.25"))})
+
+        self.assertTrue(HOST_COMPILER in row)
+        self.assertTrue(CMAKE in row)
+        self.assertFalse(DEVICE_COMPILER in row)
+
+        self.assertTrue(row[HOST_COMPILER].name == GCC)
+        self.assertTrue(row[HOST_COMPILER].version == packaging.version.parse(str(13)))
+        self.assertTrue(row[CMAKE].name == CMAKE)
+        self.assertTrue(row[CMAKE].version == packaging.version.parse("3.25"))
+
+        self.assertFalse(row[HOST_COMPILER].name == CLANG)
+        self.assertFalse(row[CMAKE].version == packaging.version.parse("3.15"))
+
+        self.assertFalse(row[DEVICE_COMPILER].name == GCC)
+        self.assertFalse(row[DEVICE_COMPILER].name == CLANG)
+        self.assertFalse(row[DEVICE_COMPILER].version == packaging.version.parse(str(13)))
+        self.assertFalse(row[DEVICE_COMPILER].version == packaging.version.parse("7.25"))
+
+        # check if test statement without key-existing-check returns the same result as test
+        # statement with key-existing-check
+        self.assertEqual(
+            row[HOST_COMPILER].name == GCC, HOST_COMPILER in row and row[HOST_COMPILER].name == GCC
+        )
+        self.assertEqual(
+            row[HOST_COMPILER].name == CLANG,
+            HOST_COMPILER in row and row[HOST_COMPILER].name == CLANG,
+        )
+        self.assertEqual(
+            row[CMAKE].version == packaging.version.parse("3.25"),
+            CMAKE in row and row[CMAKE].version == packaging.version.parse("3.25"),
+        )
+        self.assertEqual(
+            row[CMAKE].version == packaging.version.parse("3.17"),
+            CMAKE in row and row[CMAKE].version == packaging.version.parse("3.17"),
+        )
+
+        self.assertEqual(
+            row[DEVICE_COMPILER].name == GCC,
+            DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == GCC,
+        )
+        self.assertEqual(
+            row[DEVICE_COMPILER].name == CLANG,
+            DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == CLANG,
+        )
+        self.assertEqual(
+            row[DEVICE_COMPILER].version == packaging.version.parse("3.25"),
+            DEVICE_COMPILER in row
+            and row[DEVICE_COMPILER].version == packaging.version.parse("3.25"),
+        )
+        self.assertEqual(
+            row[DEVICE_COMPILER].version == packaging.version.parse("3.17"),
+            DEVICE_COMPILER in row
+            and row[DEVICE_COMPILER].version == packaging.version.parse("3.17"),
+        )

--- a/tests/test_clang_cuda.py
+++ b/tests/test_clang_cuda.py
@@ -3,7 +3,6 @@ import unittest
 import io
 
 from typing import List, Tuple
-from collections import OrderedDict as OD
 import packaging.version as pkv
 from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -12,6 +11,7 @@ from bashi.version.relation import VersionRelation
 from bashi.version.dependencies.clang_cuda import CLANG_CUDA_MAX_CUDA_VERSION
 from bashi.filter_compiler import compiler_filter_typechecked
 from bashi.filter_backend import backend_filter_typechecked
+from bashi.row import BashiRow
 
 
 class TestClangCUDACompilerFilter(unittest.TestCase):
@@ -22,7 +22,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, 15)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -35,7 +35,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, 15)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -79,7 +79,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
 
                 self.assertEqual(
                     compiler_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((CLANG_CUDA, clang_cuda_version)),
                                 ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -116,7 +116,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 9.0)),
@@ -129,7 +129,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -145,7 +145,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -163,7 +163,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, 15)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -176,7 +176,7 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, 15)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -190,9 +190,11 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
 
     def test_valid_clang_cuda_does_not_support_the_sycl_backend_c18(self):
         for row in [
-            OD({HOST_COMPILER: ppv((CLANG_CUDA, 15))}),
-            OD({DEVICE_COMPILER: ppv((CLANG_CUDA, 14))}),
-            OD({HOST_COMPILER: ppv((CLANG_CUDA, 17)), DEVICE_COMPILER: ppv((CLANG_CUDA, 17))}),
+            BashiRow({HOST_COMPILER: ppv((CLANG_CUDA, 15))}),
+            BashiRow({DEVICE_COMPILER: ppv((CLANG_CUDA, 14))}),
+            BashiRow(
+                {HOST_COMPILER: ppv((CLANG_CUDA, 17)), DEVICE_COMPILER: ppv((CLANG_CUDA, 17))}
+            ),
         ]:
             for comb in [
                 [ALPAKA_ACC_ONEAPI_CPU_ENABLE],
@@ -213,9 +215,11 @@ class TestClangCUDACompilerFilter(unittest.TestCase):
 
     def test_invalid_clang_cuda_does_not_support_the_sycl_backend_c18(self):
         for row in [
-            OD({HOST_COMPILER: ppv((CLANG_CUDA, 15))}),
-            OD({DEVICE_COMPILER: ppv((CLANG_CUDA, 14))}),
-            OD({HOST_COMPILER: ppv((CLANG_CUDA, 17)), DEVICE_COMPILER: ppv((CLANG_CUDA, 17))}),
+            BashiRow({HOST_COMPILER: ppv((CLANG_CUDA, 15))}),
+            BashiRow({DEVICE_COMPILER: ppv((CLANG_CUDA, 14))}),
+            BashiRow(
+                {HOST_COMPILER: ppv((CLANG_CUDA, 17)), DEVICE_COMPILER: ppv((CLANG_CUDA, 17))}
+            ),
         ]:
             for comb in [
                 [(ALPAKA_ACC_ONEAPI_CPU_ENABLE, ON)],
@@ -292,7 +296,7 @@ class TestClangCUDABackendFilter(unittest.TestCase):
                 reason_msg1 = io.StringIO()
                 self.assertEqual(
                     backend_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((CLANG_CUDA, clang_cuda_version)),
                                 ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -329,7 +333,7 @@ class TestClangCUDABackendFilter(unittest.TestCase):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 9.0)),
@@ -342,7 +346,7 @@ class TestClangCUDABackendFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -358,7 +362,7 @@ class TestClangCUDABackendFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             compiler_type: ppv((CLANG_CUDA, unsupported_new_clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(

--- a/tests/test_clang_cuda_filter.py
+++ b/tests/test_clang_cuda_filter.py
@@ -2,11 +2,11 @@
 import unittest
 import io
 
-from collections import OrderedDict as OD
 from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter_compiler import compiler_filter_typechecked
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class TestClangCudaOldVersions(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestClangCudaOldVersions(unittest.TestCase):
         for clang_cuda_version in [14, 16, 18, 78]:
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
                             DEVICE_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
@@ -31,7 +31,7 @@ class TestClangCudaOldVersions(unittest.TestCase):
         for clang_cuda_version in [14, 16, 18, 78]:
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -48,7 +48,7 @@ class TestClangCudaOldVersions(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
                             DEVICE_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
@@ -68,7 +68,7 @@ class TestClangCudaOldVersions(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG_CUDA, clang_cuda_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),

--- a/tests/test_compiler_cxx_support.py
+++ b/tests/test_compiler_cxx_support.py
@@ -2,7 +2,6 @@
 # pylint: disable=too-many-lines
 import unittest
 import io
-from collections import OrderedDict as OD
 import packaging.version as pkv
 from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -14,6 +13,7 @@ from bashi.filter_compiler import (
     _get_max_supported_cxx_version_for_cuda_sdk_for_clang_cuda,
     _get_max_supported_cxx_version_for_cuda_sdk,
 )
+from bashi.row import BashiRow
 
 
 class TestGetMaximumSupportedCXXStandardForCUDASdk(unittest.TestCase):
@@ -189,101 +189,103 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_ignore_combination_gcc_cxx_support_c21(self):
         self.assertTrue(
-            compiler_filter_typechecked(OD({HOST_COMPILER: ppv((GCC, 10))}), self.version_relation)
-        )
-        self.assertTrue(
             compiler_filter_typechecked(
-                OD({CXX_STANDARD: ppv((CXX_STANDARD, 20))}), self.version_relation
+                BashiRow({HOST_COMPILER: ppv((GCC, 10))}), self.version_relation
             )
         )
         self.assertTrue(
             compiler_filter_typechecked(
-                OD({CXX_STANDARD: ppv((CXX_STANDARD, 20)), CMAKE: ppv((CMAKE, 3.18))}),
+                BashiRow({CXX_STANDARD: ppv((CXX_STANDARD, 20))}), self.version_relation
+            )
+        )
+        self.assertTrue(
+            compiler_filter_typechecked(
+                BashiRow({CXX_STANDARD: ppv((CXX_STANDARD, 20)), CMAKE: ppv((CMAKE, 3.18))}),
                 self.version_relation,
             )
         )
 
     def test_valid_in_range_gcc_cxx_support_c21(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 0)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 16)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 16)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 9)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 9)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 10)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 10)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 10)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 11)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 11)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 11)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 9999)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
@@ -294,73 +296,73 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_invalid_in_range_gcc_cxx_support_c21(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 9999)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((GCC, 8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 18)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((GCC, 8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((GCC, 8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((GCC, 9)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 18)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 10)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 21)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 11)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 24)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 11)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 26)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 13)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 26)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 9999)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 26)),
@@ -387,49 +389,49 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_valid_in_range_clang_cxx_support_c22(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 0)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 9)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 13)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 14)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 14)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 17)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 9999)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
@@ -440,37 +442,37 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_invalid_in_range_clang_cxx_support_c22(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 9999)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG, 8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 13)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 16)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 9999)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 9999)),
@@ -497,43 +499,43 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_valid_in_range_nvcc_cxx_support_c23(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 10.1)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 0)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 11.0)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 11.0)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 12.3)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 12.8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 12.0)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 99.0)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
@@ -544,25 +546,25 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_invalid_in_range_nvcc_cxx_support_c23(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 10.2)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 9999)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 10.2)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 11.8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((NVCC, 12.9)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
@@ -582,33 +584,33 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_valid_combination_cxx_cuda_backend_host_compiler_c24(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 12)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.0)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 12)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.0)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 15)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.8)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 11)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
@@ -624,28 +626,28 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_invalid_combination_cxx_cuda_backend_host_compiler_c24(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 12)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.1)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 14)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.5)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG, 16)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.8)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((GCC, 11)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
@@ -668,31 +670,31 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_valid_in_range_clang_cuda_cxx_support_c25(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG_CUDA, 14)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG_CUDA, 14)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG_CUDA, 14)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG_CUDA, 17)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((CLANG_CUDA, 9999)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
@@ -703,25 +705,25 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_invalid_in_range_clang_cuda_cxx_support_c25(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG_CUDA, 14)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG_CUDA, 16)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG_CUDA, 18)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 26)),
                 },
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((CLANG_CUDA, 9999)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 9999)),
@@ -748,43 +750,43 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_valid_cuda_sdk_max_supported_cxx_c26(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 9)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 11)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 10.1)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 10.2)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.5)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.1)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.1)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
@@ -795,25 +797,25 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
 
     def test_invalid_cuda_sdk_max_supported_cxx_c26(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 10.1)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.4)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.0)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 9999.0)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 99)),
@@ -846,7 +848,7 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
         # case anymore, the test needs to be modified.
         self.assertGreater(max_clang_cuda_support_cxx.cxx, max_nvcc_supported_cxx.cxx)
 
-        valid_row = OD(
+        valid_row = BashiRow(
             {
                 ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
                     (ALPAKA_ACC_GPU_CUDA_ENABLE, str(max_clang_cuda_support_cxx.compiler))
@@ -859,7 +861,7 @@ class TestCompilerCXXSupportFilterRules(unittest.TestCase):
         )
 
         invalid_cuda_sdk_version = float(str(max_clang_cuda_support_cxx.compiler)) + 0.1
-        invalid_row = OD(
+        invalid_row = BashiRow(
             {
                 ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
                     (
@@ -929,25 +931,25 @@ class TestClangBasedCompilerCXXSupport(unittest.TestCase):
 
     def test_valid_icpx_supported_cxx_c27(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((ICPX, "2025.0")),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((ICPX, "2025.0")),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((ICPX, "2025.0")),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((ICPX, "2025.0")),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
@@ -958,13 +960,13 @@ class TestClangBasedCompilerCXXSupport(unittest.TestCase):
 
     def test_invalid_icpx_supported_cxx_c27(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((ICPX, "2025.0")),
                     CXX_STANDARD: ppv((CXX_STANDARD, 26)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((ICPX, "2025.0")),
                     CXX_STANDARD: ppv((CXX_STANDARD, 99)),
@@ -991,25 +993,25 @@ class TestClangBasedCompilerCXXSupport(unittest.TestCase):
 
     def test_valid_hipcc_supported_cxx_c28(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((HIPCC, 5.7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 14)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((HIPCC, 6.0)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 17)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((HIPCC, 6.1)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 20)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((HIPCC, 5.7)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 23)),
@@ -1020,13 +1022,13 @@ class TestClangBasedCompilerCXXSupport(unittest.TestCase):
 
     def test_invalid_hipcc_supported_cxx_c28(self):
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ppv((HIPCC, 6.3)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 26)),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     DEVICE_COMPILER: ppv((HIPCC, 6.8)),
                     CXX_STANDARD: ppv((CXX_STANDARD, 99)),

--- a/tests/test_filter_chain.py
+++ b/tests/test_filter_chain.py
@@ -1,18 +1,18 @@
 # pylint: disable=missing-docstring
 import unittest
 from typing import IO, Dict, List, Callable
-from collections import OrderedDict
 import packaging.version as pkv
-from bashi.types import ParameterValue, ParameterValueTuple, FilterFunction
+from bashi.types import ParameterValue
 from bashi.filter import FilterBase
 from bashi.filter_chain import get_default_filter_chain
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class TestFilterChain(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.param_val_tuple: ParameterValueTuple = OrderedDict()
+        cls.param_val_tuple = BashiRow({})
         cls.param_val_tuple["param1"] = ParameterValue("param-val-name1", pkv.parse("1"))
         cls.param_val_tuple["param2"] = ParameterValue("param-val-name2", pkv.parse("2"))
         cls.param_val_tuple["param3"] = ParameterValue("param-val-name3", pkv.parse("3"))
@@ -42,14 +42,14 @@ class TestFilterChain(unittest.TestCase):
             ):
                 super().__init__(runtime_infos, output)
 
-            def __call__(self, row: ParameterValueTuple):
+            def __call__(self, row: BashiRow):
                 if "paramNotExist" in row:
                     return False
                 return True
 
         custom_filter = CustomFilter()
 
-        filter_chain: FilterFunction = get_default_filter_chain(
+        filter_chain = get_default_filter_chain(
             version_relation=VersionRelation(), custom_filter=custom_filter
         )
         self.assertTrue(
@@ -68,14 +68,14 @@ class TestFilterChain(unittest.TestCase):
             ):
                 super().__init__(runtime_infos, output)
 
-            def __call__(self, row: ParameterValueTuple):
+            def __call__(self, row: BashiRow):
                 if "param2" in row:
                     return False
                 return True
 
         custom_filter = CustomFilter()
 
-        filter_chain: FilterFunction = get_default_filter_chain(
+        filter_chain = get_default_filter_chain(
             version_relation=VersionRelation(), custom_filter=custom_filter
         )
         self.assertFalse(

--- a/tests/test_filter_compiler_name.py
+++ b/tests/test_filter_compiler_name.py
@@ -2,16 +2,16 @@
 import unittest
 
 import io
-from collections import OrderedDict as OD
 from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter_compiler import compiler_filter_typechecked
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class TestEmptyRow(unittest.TestCase):
     def test_empty_row_shall_always_pass(self):
-        self.assertTrue(compiler_filter_typechecked(OD(), VersionRelation()))
+        self.assertTrue(compiler_filter_typechecked(BashiRow({}), VersionRelation()))
 
 
 class TestHostDeviceCompilerSameName(unittest.TestCase):
@@ -28,14 +28,15 @@ class TestHostDeviceCompilerSameName(unittest.TestCase):
         ]:
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}), self.version_relation
+                    BashiRow({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}),
+                    self.version_relation,
                 ),
                 f"host compiler and device compiler name are not the same: {comb[0]} != {comb[1]}",
             )
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG_CUDA, 15)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -49,7 +50,7 @@ class TestHostDeviceCompilerSameName(unittest.TestCase):
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 10)),
                         DEVICE_COMPILER: ppv((CLANG, 10)),
@@ -75,7 +76,7 @@ class TestHostDeviceCompilerSameName(unittest.TestCase):
 
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}),
+                    BashiRow({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}),
                     self.version_relation,
                     reason_msg,
                 ),
@@ -89,7 +90,7 @@ class TestHostDeviceCompilerSameName(unittest.TestCase):
         reason_msg_multi1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG_CUDA, 10)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -109,7 +110,7 @@ class TestHostDeviceCompilerSameName(unittest.TestCase):
         reason_msg_multi2 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 15)),
                         DEVICE_COMPILER: ppv((CLANG, 10)),

--- a/tests/test_filter_compiler_version.py
+++ b/tests/test_filter_compiler_version.py
@@ -2,16 +2,16 @@
 import unittest
 
 import io
-from collections import OrderedDict as OD
 from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter_compiler import compiler_filter_typechecked
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class TestEmptyRow(unittest.TestCase):
     def test_empty_row_shall_always_pass(self):
-        self.assertTrue(compiler_filter_typechecked(OD(), VersionRelation()))
+        self.assertTrue(compiler_filter_typechecked(BashiRow({}), VersionRelation()))
 
 
 class TestHostDeviceCompilerSameVersion(unittest.TestCase):
@@ -28,14 +28,15 @@ class TestHostDeviceCompilerSameVersion(unittest.TestCase):
         ]:
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}), self.version_relation
+                    BashiRow({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}),
+                    self.version_relation,
                 ),
                 f"host compiler and device compiler version are not the same: {comb[0]} != {comb[1]}",
             )
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG_CUDA, 14)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -49,7 +50,7 @@ class TestHostDeviceCompilerSameVersion(unittest.TestCase):
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 14)),
                         DEVICE_COMPILER: ppv((CLANG, 14)),
@@ -76,7 +77,7 @@ class TestHostDeviceCompilerSameVersion(unittest.TestCase):
 
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}),
+                    BashiRow({HOST_COMPILER: comb[0], DEVICE_COMPILER: comb[1]}),
                     self.version_relation,
                     reason_msg,
                 ),
@@ -90,7 +91,7 @@ class TestHostDeviceCompilerSameVersion(unittest.TestCase):
         reason_msg_multi1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG_CUDA, 10)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -110,7 +111,7 @@ class TestHostDeviceCompilerSameVersion(unittest.TestCase):
         reason_msg_multi2 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 15)),
                         DEVICE_COMPILER: ppv((GCC, 10)),

--- a/tests/test_filter_software_dependency.py
+++ b/tests/test_filter_software_dependency.py
@@ -3,7 +3,6 @@ import unittest
 import io
 
 from typing import Dict, Callable
-from collections import OrderedDict as OD
 from utils_test import parse_param_val as ppv
 from utils_test import parse_value_version
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
@@ -14,6 +13,7 @@ from bashi.filter_software_dependency import (
 from bashi.runtime_info import ValidUbuntuSDK
 from bashi.version.dependencies.ubuntu import CUDA_MIN_UBUNTU
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
@@ -24,14 +24,16 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
         for gcc_version in [7, 13, 99]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD({HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "22.04"))}),
+                    BashiRow(
+                        {HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "22.04"))}
+                    ),
                     self.version_relation,
                 )
             )
 
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((GCC, gcc_version)),
                             UBUNTU: ppv((UBUNTU, "22.04")),
@@ -43,14 +45,16 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
         for gcc_version in [7, 13, 99]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD({HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "20.04"))}),
+                    BashiRow(
+                        {HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "20.04"))}
+                    ),
                     self.version_relation,
                 )
             )
 
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((GCC, gcc_version)),
                             UBUNTU: ppv((UBUNTU, "20.04")),
@@ -62,21 +66,25 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
         for gcc_version in [1, 3, 6, 7, 13, 99]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD({HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "18.04"))}),
+                    BashiRow(
+                        {HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "18.04"))}
+                    ),
                     self.version_relation,
                 )
             )
         for gcc_version in [1, 3, 6, 7, 13, 99]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD({DEVICE_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "18.04"))}),
+                    BashiRow(
+                        {DEVICE_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "18.04"))}
+                    ),
                     self.version_relation,
                 )
             )
         for gcc_version in [1, 3, 6, 7, 13, 99]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((GCC, gcc_version)),
                             UBUNTU: ppv((UBUNTU, "18.04")),
@@ -88,7 +96,7 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
         for gcc_version in [1, 3, 6, 7, 13, 99]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, gcc_version)),
                             UBUNTU: ppv((UBUNTU, "18.04")),
@@ -103,7 +111,9 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD({HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "20.04"))}),
+                    BashiRow(
+                        {HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "20.04"))}
+                    ),
                     self.version_relation,
                     reason_msg,
                 ),
@@ -117,7 +127,9 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD({HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "22.04"))}),
+                    BashiRow(
+                        {HOST_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "22.04"))}
+                    ),
                     self.version_relation,
                     reason_msg,
                 ),
@@ -132,7 +144,9 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD({DEVICE_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "20.04"))}),
+                    BashiRow(
+                        {DEVICE_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "20.04"))}
+                    ),
                     self.version_relation,
                     reason_msg,
                 ),
@@ -146,7 +160,9 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD({DEVICE_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "22.04"))}),
+                    BashiRow(
+                        {DEVICE_COMPILER: ppv((GCC, gcc_version)), UBUNTU: ppv((UBUNTU, "22.04"))}
+                    ),
                     self.version_relation,
                     reason_msg,
                 ),
@@ -161,7 +177,7 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
         for cmake_version in ["3.19", "3.26", "3.20", "3.49"]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG_CUDA, 14)),
                             CMAKE: ppv((CMAKE, cmake_version)),
@@ -174,7 +190,7 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
         for cmake_version in ["3.19", "3.26", "3.20", "3.49"]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((CLANG_CUDA, 15)),
                             CMAKE: ppv((CMAKE, cmake_version)),
@@ -189,7 +205,9 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD({HOST_COMPILER: ppv((CLANG_CUDA, 14)), CMAKE: ppv((CMAKE, cmake_version))}),
+                    BashiRow(
+                        {HOST_COMPILER: ppv((CLANG_CUDA, 14)), CMAKE: ppv((CMAKE, cmake_version))}
+                    ),
                     self.version_relation,
                     reason_msg,
                 ),
@@ -204,7 +222,7 @@ class TestOldGCCVersionInUbuntu2004(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {DEVICE_COMPILER: ppv((CLANG_CUDA, 15)), CMAKE: ppv((CMAKE, cmake_version))}
                     ),
                     self.version_relation,
@@ -234,7 +252,7 @@ class TestHIPUbuntu(unittest.TestCase):
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
                 self.assertTrue(
                     software_dependency_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((HIPCC, hipcc_ver)),
                                 UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -258,7 +276,7 @@ class TestHIPUbuntu(unittest.TestCase):
                 reason_msg = io.StringIO()
                 self.assertFalse(
                     software_dependency_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((HIPCC, hipcc_ver)),
                                 UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -286,7 +304,7 @@ class TestHIPUbuntu(unittest.TestCase):
         ]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -312,7 +330,7 @@ class TestHIPUbuntu(unittest.TestCase):
         ]:
             self.assertTrue(
                 sw_dep_filter(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -341,7 +359,7 @@ class TestHIPUbuntu(unittest.TestCase):
 
             self.assertFalse(
                 sw_dep_filter(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -376,7 +394,7 @@ class TestCUDAUbuntu(unittest.TestCase):
         ]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, nvcc_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -397,7 +415,7 @@ class TestCUDAUbuntu(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, nvcc_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -434,7 +452,7 @@ class TestCUDAUbuntu(unittest.TestCase):
         ]:
             self.assertTrue(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, cuda_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -455,7 +473,7 @@ class TestCUDAUbuntu(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertFalse(
                 software_dependency_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, cuda_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -490,7 +508,7 @@ class TestCUDAUbuntu(unittest.TestCase):
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
                 self.assertTrue(
                     software_dependency_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((CLANG_CUDA, clang_cuda_ver)),
                                 UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -509,7 +527,7 @@ class TestCUDAUbuntu(unittest.TestCase):
                 reason_msg = io.StringIO()
                 self.assertFalse(
                     software_dependency_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((CLANG_CUDA, clang_cuda_ver)),
                                 UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -539,7 +557,7 @@ class TestCUDAUbuntu(unittest.TestCase):
                 reason_msg = io.StringIO()
                 self.assertFalse(
                     software_dependency_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((CLANG_CUDA, clang_cuda_ver)),
                                 UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -575,7 +593,7 @@ class TestCUDAUbuntu(unittest.TestCase):
             for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
                 self.assertTrue(
                     sw_dep_filter(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((CLANG_CUDA, clang_cuda_ver)),
                                 UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -606,7 +624,7 @@ class TestCUDAUbuntu(unittest.TestCase):
 
                 self.assertFalse(
                     sw_dep_filter(
-                        OD(
+                        BashiRow(
                             {
                                 compiler_type: ppv((CLANG_CUDA, clang_cuda_ver)),
                                 UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -638,7 +656,7 @@ class TestCUDAUbuntu(unittest.TestCase):
         ]:
             self.assertTrue(
                 sw_dep_filter(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, cuda_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -668,7 +686,7 @@ class TestCUDAUbuntu(unittest.TestCase):
 
             self.assertFalse(
                 sw_dep_filter(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, cuda_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -699,7 +717,7 @@ class TestCUDAUbuntu(unittest.TestCase):
         ]:
             self.assertTrue(
                 sw_dep_filter(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, cuda_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),
@@ -729,7 +747,7 @@ class TestCUDAUbuntu(unittest.TestCase):
 
             self.assertFalse(
                 sw_dep_filter(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, nvcc_ver)),
                             UBUNTU: ppv((UBUNTU, ubuntu_ver)),

--- a/tests/test_generate_combination_list.py
+++ b/tests/test_generate_combination_list.py
@@ -20,11 +20,11 @@ from bashi.results import get_expected_bashi_parameter_value_pairs
 from bashi.types import (
     ParameterValue,
     ParameterValuePair,
-    ParameterValueTuple,
     ParameterValueMatrix,
 )
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter import FilterBase
+from bashi.row import BashiRow
 
 
 class TestGeneratorTestData(unittest.TestCase):
@@ -78,7 +78,7 @@ class TestGeneratorTestData(unittest.TestCase):
             ):
                 super().__init__(runtime_infos, VersionRelation(), output)
 
-            def __call__(self, row: ParameterValueTuple):
+            def __call__(self, row: BashiRow):
                 if DEVICE_COMPILER in row and row[DEVICE_COMPILER].name == NVCC:
                     return False
 
@@ -94,35 +94,33 @@ class TestGeneratorTestData(unittest.TestCase):
 
         custom_filter = CustomFilter()
 
-        OD = OrderedDict
-
         for row in [
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     DEVICE_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     DEVICE_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     CMAKE: ParameterValue(CMAKE, pkv.parse("3.23")),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     DEVICE_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     BOOST: ParameterValue(BOOST, pkv.parse("1.82")),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     DEVICE_COMPILER: ParameterValue(GCC, pkv.parse("10")),
@@ -130,7 +128,7 @@ class TestGeneratorTestData(unittest.TestCase):
                     BOOST: ParameterValue(BOOST, pkv.parse("1.81")),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     DEVICE_COMPILER: ParameterValue(GCC, pkv.parse("10")),
@@ -138,7 +136,7 @@ class TestGeneratorTestData(unittest.TestCase):
                     BOOST: ParameterValue(BOOST, pkv.parse("1.81")),
                 }
             ),
-            OD(
+            BashiRow(
                 {
                     HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                     DEVICE_COMPILER: ParameterValue(GCC, pkv.parse("10")),
@@ -151,7 +149,7 @@ class TestGeneratorTestData(unittest.TestCase):
 
         self.assertFalse(
             custom_filter(
-                OrderedDict(
+                BashiRow(
                     {
                         HOST_COMPILER: ParameterValue(GCC, pkv.parse("10")),
                         DEVICE_COMPILER: ParameterValue(GCC, pkv.parse("10")),
@@ -280,7 +278,7 @@ class TestGeneratorRealData(unittest.TestCase):
             ):
                 super().__init__(runtime_infos, VersionRelation(), output)
 
-            def __call__(self, row: ParameterValueTuple):
+            def __call__(self, row: BashiRow):
                 if (
                     CMAKE in row
                     and row[CMAKE].version == pkv.parse("3.23")

--- a/tests/test_hipcc_filter.py
+++ b/tests/test_hipcc_filter.py
@@ -1,12 +1,12 @@
 # pylint: disable=missing-docstring
 import unittest
 import io
-from collections import OrderedDict as OD
 from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter_compiler import compiler_filter_typechecked
 from bashi.filter_backend import backend_filter_typechecked
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class TestHipccCompilerFilter(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         for version in (4.5, 5.3, 6.0):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -29,7 +29,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -41,7 +41,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             DEVICE_COMPILER: ppv((HIPCC, version)),
@@ -54,7 +54,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -67,7 +67,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -85,7 +85,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -100,7 +100,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg2 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -115,7 +115,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg3 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             DEVICE_COMPILER: ppv((HIPCC, version)),
@@ -131,7 +131,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg4 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -147,7 +147,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg5 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -166,7 +166,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         for compiler_name in set(COMPILERS) - set([NVCC, HIPCC]):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -179,7 +179,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -192,7 +192,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
@@ -206,7 +206,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((compiler_name, 9999)),
@@ -222,7 +222,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 9999)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -236,7 +236,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         for host_compiler in (GCC, CLANG):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((host_compiler, 9999)),
                             DEVICE_COMPILER: ppv((NVCC, 9999)),
@@ -250,7 +250,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((host_compiler, 9999)),
@@ -269,7 +269,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -287,7 +287,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg2 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -305,7 +305,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg3 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
@@ -324,7 +324,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg4 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((compiler_name, 9999)),
@@ -345,7 +345,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         reason_msg5 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 9999)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -364,7 +364,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg6 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((host_compiler, 9999)),
                             DEVICE_COMPILER: ppv((NVCC, 9999)),
@@ -381,7 +381,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg7 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((host_compiler, 9999)),
@@ -400,9 +400,11 @@ class TestHipccCompilerFilter(unittest.TestCase):
     def test_hipcc_requires_disabled_sycl_backend_pass_c10(self):
         for version in (4.5, 5.3, 6.0):
             for row in [
-                OD({HOST_COMPILER: ppv((HIPCC, version))}),
-                OD({DEVICE_COMPILER: ppv((HIPCC, version))}),
-                OD({HOST_COMPILER: ppv((HIPCC, version)), DEVICE_COMPILER: ppv((HIPCC, version))}),
+                BashiRow({HOST_COMPILER: ppv((HIPCC, version))}),
+                BashiRow({DEVICE_COMPILER: ppv((HIPCC, version))}),
+                BashiRow(
+                    {HOST_COMPILER: ppv((HIPCC, version)), DEVICE_COMPILER: ppv((HIPCC, version))}
+                ),
             ]:
                 for comb in [
                     [ALPAKA_ACC_ONEAPI_CPU_ENABLE],
@@ -426,9 +428,11 @@ class TestHipccCompilerFilter(unittest.TestCase):
     def test_hipcc_requires_disabled_sycl_backend_not_pass_c10(self):
         for version in (4.5, 5.3, 6.0):
             for row in [
-                OD({HOST_COMPILER: ppv((HIPCC, version))}),
-                OD({DEVICE_COMPILER: ppv((HIPCC, version))}),
-                OD({HOST_COMPILER: ppv((HIPCC, version)), DEVICE_COMPILER: ppv((HIPCC, version))}),
+                BashiRow({HOST_COMPILER: ppv((HIPCC, version))}),
+                BashiRow({DEVICE_COMPILER: ppv((HIPCC, version))}),
+                BashiRow(
+                    {HOST_COMPILER: ppv((HIPCC, version)), DEVICE_COMPILER: ppv((HIPCC, version))}
+                ),
             ]:
                 for comb in [
                     [(ALPAKA_ACC_ONEAPI_CPU_ENABLE, ON)],
@@ -473,7 +477,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
     def test_hip_and_sycl_backend_cannot_be_active_at_the_same_time_b2(self):
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
@@ -485,7 +489,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                         ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF)),
@@ -497,7 +501,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
                         ALPAKA_ACC_ONEAPI_FPGA_ENABLE: ppv((ALPAKA_ACC_ONEAPI_FPGA_ENABLE, ON)),
@@ -510,7 +514,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                         ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, ON)),
@@ -526,7 +530,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -541,7 +545,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -561,7 +565,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         for version in (4.5, 5.3, 6.0):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -573,7 +577,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -585,7 +589,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             DEVICE_COMPILER: ppv((HIPCC, version)),
@@ -598,7 +602,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -611,7 +615,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -629,7 +633,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -644,7 +648,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg2 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((HIPCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -659,7 +663,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg3 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((HIPCC, version)),
                             DEVICE_COMPILER: ppv((HIPCC, version)),
@@ -675,7 +679,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg4 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -691,7 +695,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
             reason_msg5 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((HIPCC, version)),
@@ -709,7 +713,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
     def test_hip_and_cuda_backend_cannot_be_active_at_the_same_time_b3(self):
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -721,7 +725,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -733,7 +737,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -746,7 +750,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -762,7 +766,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -777,7 +781,7 @@ class TestHipccCompilerFilter(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),

--- a/tests/test_icpx_filter.py
+++ b/tests/test_icpx_filter.py
@@ -1,13 +1,12 @@
 # pylint: disable=missing-docstring
 import unittest
 import io
-from collections import OrderedDict as OD
 from utils_test import parse_param_val as ppv
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.filter_compiler import compiler_filter_typechecked
 from bashi.filter_backend import backend_filter_typechecked
-from bashi.types import ParameterValueTuple
 from bashi.version.relation import VersionRelation
+from bashi.row import BashiRow
 
 
 class TestIcpxCompilerFilter(unittest.TestCase):
@@ -67,7 +66,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
                     (ALPAKA_ACC_ONEAPI_FPGA_ENABLE, ON),
                 ],
             ]:
-                row: ParameterValueTuple = OD()
+                row = BashiRow({})
                 for name, value in comb:
                     if name in (HOST_COMPILER, DEVICE_COMPILER):
                         row[name] = ppv((ICPX, value))
@@ -78,7 +77,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((ICPX, icpx_version)),
@@ -114,7 +113,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
                     (ALPAKA_ACC_ONEAPI_FPGA_ENABLE, OFF),
                 ],
             ]:
-                row: ParameterValueTuple = OD()
+                row: BashiRow = BashiRow({})
                 for name, value in comb:
                     if name in (HOST_COMPILER, DEVICE_COMPILER):
                         row[name] = ppv((ICPX, value))
@@ -132,7 +131,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         for compiler_name in set(COMPILERS) - set([NVCC, ICPX]):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF)),
@@ -145,7 +144,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
@@ -158,7 +157,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
@@ -174,7 +173,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((compiler_name, 9999)),
@@ -190,7 +189,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF)),
@@ -205,7 +204,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF)),
@@ -223,7 +222,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 9999)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
@@ -237,7 +236,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         for host_compiler in (GCC, CLANG):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((host_compiler, 9999)),
                             DEVICE_COMPILER: ppv((NVCC, 9999)),
@@ -251,7 +250,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((host_compiler, 9999)),
@@ -270,7 +269,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),
@@ -288,7 +287,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg2 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, ON)),
@@ -306,7 +305,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg3 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
@@ -325,7 +324,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg4 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((compiler_name, 9999)),
@@ -346,7 +345,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         reason_msg5 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 9999)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),
@@ -365,7 +364,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg6 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((host_compiler, 9999)),
                             DEVICE_COMPILER: ppv((NVCC, 9999)),
@@ -382,7 +381,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg7 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((host_compiler, 9999)),
@@ -401,7 +400,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         reason_msg8 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 11)),
                         ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF)),
@@ -420,7 +419,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         reason_msg9 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 11)),
                         ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF)),
@@ -441,7 +440,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -453,7 +452,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -465,7 +464,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             DEVICE_COMPILER: ppv((ICPX, version)),
@@ -478,7 +477,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -491,7 +490,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -509,7 +508,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -524,7 +523,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg2 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -539,7 +538,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg3 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             DEVICE_COMPILER: ppv((ICPX, version)),
@@ -555,7 +554,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg4 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -571,7 +570,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg5 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -589,7 +588,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
     def test_sycl_and_hip_backend_cannot_be_active_at_the_same_time_b5(self):
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -601,7 +600,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, ON)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -613,7 +612,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_FPGA_ENABLE: ppv((ALPAKA_ACC_ONEAPI_FPGA_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -626,7 +625,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -642,7 +641,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -657,7 +656,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -678,7 +677,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         for version in ("2023.3.0", "2024.2.1", "2024.3.0"):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -690,7 +689,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -702,7 +701,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             DEVICE_COMPILER: ppv((ICPX, version)),
@@ -715,7 +714,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -728,7 +727,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -746,7 +745,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -761,7 +760,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg2 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((ICPX, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -776,7 +775,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg3 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((ICPX, version)),
                             DEVICE_COMPILER: ppv((ICPX, version)),
@@ -792,7 +791,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg4 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -808,7 +807,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
             reason_msg5 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((ICPX, version)),
@@ -826,7 +825,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
     def test_sycl_and_cuda_backend_cannot_be_active_at_the_same_time_b6(self):
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -838,7 +837,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, ON)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -850,7 +849,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_FPGA_ENABLE: ppv((ALPAKA_ACC_ONEAPI_FPGA_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -863,7 +862,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, ON)),
@@ -879,7 +878,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
@@ -894,7 +893,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),
@@ -931,7 +930,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
                 (ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON),
             ],
         ]:
-            row: ParameterValueTuple = OD()
+            row = BashiRow({})
             for name, value in comb:
                 row[name] = ppv((name, value))
             self.assertTrue(backend_filter_typechecked(row, self.version_relation), f"{row}")
@@ -956,7 +955,7 @@ class TestIcpxCompilerFilter(unittest.TestCase):
                 (ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON),
             ],
         ]:
-            row: ParameterValueTuple = OD()
+            row = BashiRow({})
             for name, value in comb:
                 row[name] = ppv((name, value))
 

--- a/tests/test_nvcc_filter.py
+++ b/tests/test_nvcc_filter.py
@@ -2,16 +2,15 @@
 import unittest
 import io
 
-from collections import OrderedDict as OD
 import packaging.version as pkv
 from utils_test import parse_param_val as ppv
+from bashi.row import BashiRow
 from bashi.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from bashi.version import VERSIONS
 from bashi.version.relation import VersionRelation
 from bashi.version.dependencies.nvcc import NvccHostSupport
 from bashi.filter_compiler import compiler_filter_typechecked
 from bashi.filter_backend import backend_filter_typechecked
-from bashi.types import ParameterValueTuple
 
 
 class TestNoNvccHostCompiler(unittest.TestCase):
@@ -21,7 +20,7 @@ class TestNoNvccHostCompiler(unittest.TestCase):
     def test_valid_combination_rule_c1(self):
         self.assertTrue(
             compiler_filter_typechecked(
-                OD({HOST_COMPILER: ppv((GCC, 10)), DEVICE_COMPILER: ppv((NVCC, 11.2))}),
+                BashiRow({HOST_COMPILER: ppv((GCC, 10)), DEVICE_COMPILER: ppv((NVCC, 11.2))}),
                 self.version_relation,
             )
         )
@@ -29,14 +28,14 @@ class TestNoNvccHostCompiler(unittest.TestCase):
         # version should not matter
         self.assertTrue(
             compiler_filter_typechecked(
-                OD({HOST_COMPILER: ppv((CLANG, 0)), DEVICE_COMPILER: ppv((NVCC, 0))}),
+                BashiRow({HOST_COMPILER: ppv((CLANG, 0)), DEVICE_COMPILER: ppv((NVCC, 0))}),
                 self.version_relation,
             )
         )
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 0)),
                         DEVICE_COMPILER: ppv((NVCC, 0)),
@@ -52,7 +51,7 @@ class TestNoNvccHostCompiler(unittest.TestCase):
         # added at the next round
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 0)),
                         CMAKE: ppv((CMAKE, "3.23")),
@@ -67,7 +66,7 @@ class TestNoNvccHostCompiler(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD({HOST_COMPILER: ppv((NVCC, 11.2)), DEVICE_COMPILER: ppv((NVCC, 11.2))}),
+                BashiRow({HOST_COMPILER: ppv((NVCC, 11.2)), DEVICE_COMPILER: ppv((NVCC, 11.2))}),
                 self.version_relation,
                 reason_msg1,
             )
@@ -77,7 +76,7 @@ class TestNoNvccHostCompiler(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD({HOST_COMPILER: ppv((NVCC, 11.2)), DEVICE_COMPILER: ppv((GCC, 11))}),
+                BashiRow({HOST_COMPILER: ppv((NVCC, 11.2)), DEVICE_COMPILER: ppv((GCC, 11))}),
                 self.version_relation,
                 reason_msg2,
             )
@@ -87,7 +86,7 @@ class TestNoNvccHostCompiler(unittest.TestCase):
         reason_msg3 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD({HOST_COMPILER: ppv((NVCC, 12.2)), DEVICE_COMPILER: ppv((HIPCC, 5.1))}),
+                BashiRow({HOST_COMPILER: ppv((NVCC, 12.2)), DEVICE_COMPILER: ppv((HIPCC, 5.1))}),
                 self.version_relation,
                 reason_msg3,
             )
@@ -97,7 +96,7 @@ class TestNoNvccHostCompiler(unittest.TestCase):
         reason_msg4 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD({HOST_COMPILER: ppv((NVCC, 10.2))}), self.version_relation, reason_msg4
+                BashiRow({HOST_COMPILER: ppv((NVCC, 10.2))}), self.version_relation, reason_msg4
             )
         )
         self.assertEqual(reason_msg4.getvalue(), "nvcc is not allowed as host compiler")
@@ -113,7 +112,7 @@ class TestSupportedNvccHostCompiler(unittest.TestCase):
                 reason_msg = io.StringIO()
                 self.assertFalse(
                     compiler_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 HOST_COMPILER: ppv((compiler_name, compiler_version)),
                                 DEVICE_COMPILER: ppv((NVCC, "12.3")),
@@ -133,7 +132,7 @@ class TestSupportedNvccHostCompiler(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((HIPCC, "5.3")),
                         DEVICE_COMPILER: ppv((NVCC, "12.3")),
@@ -153,7 +152,7 @@ class TestSupportedNvccHostCompiler(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((HIPCC, "5.3")),
                         ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: ppv(
@@ -176,7 +175,7 @@ class TestSupportedNvccHostCompiler(unittest.TestCase):
             for compiler_version in ["0", "7", "10"]:
                 self.assertTrue(
                     compiler_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 HOST_COMPILER: ppv((compiler_name, compiler_version)),
                                 DEVICE_COMPILER: ppv((NVCC, "12.3")),
@@ -188,7 +187,7 @@ class TestSupportedNvccHostCompiler(unittest.TestCase):
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, "10")),
                         DEVICE_COMPILER: ppv((NVCC, "11.5")),
@@ -201,7 +200,7 @@ class TestSupportedNvccHostCompiler(unittest.TestCase):
         )
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, "7")),
                         ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: ppv(
@@ -353,7 +352,7 @@ class TestNvccSupportedGccVersion(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertEqual(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, gcc_version)),
                             DEVICE_COMPILER: ppv((NVCC, nvcc_version)),
@@ -426,7 +425,7 @@ class TestNvccSupportedGccVersion(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertEqual(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, gcc_version)),
                             DEVICE_COMPILER: ppv((NVCC, nvcc_version)),
@@ -448,7 +447,7 @@ class TestNvccSupportedGccVersion(unittest.TestCase):
     def test_valid_multi_row_entries_gcc_rule_c5(self):
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 10)),
                         DEVICE_COMPILER: ppv((NVCC, 11.2)),
@@ -462,7 +461,7 @@ class TestNvccSupportedGccVersion(unittest.TestCase):
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 12)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.1)),
@@ -480,7 +479,7 @@ class TestNvccSupportedGccVersion(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 13)),
                         DEVICE_COMPILER: ppv((NVCC, 11.2)),
@@ -500,7 +499,7 @@ class TestNvccSupportedGccVersion(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 12)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.8)),
@@ -531,7 +530,7 @@ class TestNvccSupportedGccVersion(unittest.TestCase):
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 12)),
                         DEVICE_COMPILER: ppv((NVCC, unsupported_nvcc_version)),
@@ -604,7 +603,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
             reason_msg = io.StringIO()
             self.assertEqual(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG, clang_version)),
                             DEVICE_COMPILER: ppv((NVCC, nvcc_version)),
@@ -636,7 +635,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
     def test_valid_multi_row_entries_clang_rule_c6(self):
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 10)),
                         DEVICE_COMPILER: ppv((NVCC, 11.2)),
@@ -650,7 +649,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 12)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.1)),
@@ -668,7 +667,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 13)),
                         DEVICE_COMPILER: ppv((NVCC, 11.2)),
@@ -688,7 +687,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 16)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.8)),
@@ -719,7 +718,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
 
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((CLANG, 12)),
                         DEVICE_COMPILER: ppv((NVCC, unsupported_nvcc_version)),
@@ -737,7 +736,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
                 reason_msg = io.StringIO()
                 self.assertFalse(
                     compiler_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 HOST_COMPILER: ppv((CLANG, clang_version)),
                                 DEVICE_COMPILER: ppv((NVCC, nvcc_version)),
@@ -759,7 +758,7 @@ class TestNvccSupportedClangVersion(unittest.TestCase):
                 reason_msg = io.StringIO()
                 self.assertFalse(
                     compiler_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 HOST_COMPILER: ppv((CLANG, clang_version)),
                                 ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -788,7 +787,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         for version in ("10.1", "11.2", "12.3"):
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
@@ -800,7 +799,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, 7)),
                             DEVICE_COMPILER: ppv((NVCC, version)),
@@ -813,7 +812,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
                             HOST_COMPILER: ppv((GCC, 7)),
@@ -826,7 +825,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((CLANG, 6)),
@@ -844,7 +843,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -861,7 +860,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg2 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, "11.8")),
@@ -878,7 +877,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg3 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, 7)),
                             DEVICE_COMPILER: ppv((NVCC, version)),
@@ -896,7 +895,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg4 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 12.1)),
                             HOST_COMPILER: ppv((GCC, 7)),
@@ -914,7 +913,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg5 = io.StringIO()
             self.assertFalse(
                 compiler_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((GCC, 7)),
@@ -935,7 +934,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
     def test_nvcc_requires_disabled_hip_backend_c16(self):
         self.assertTrue(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 11.2)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -948,7 +947,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 11.3)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -974,7 +973,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
                 ALPAKA_ACC_ONEAPI_FPGA_ENABLE,
             ],
         ]:
-            row: ParameterValueTuple = OD({DEVICE_COMPILER: ppv((NVCC, 11.2))})
+            row = BashiRow({DEVICE_COMPILER: ppv((NVCC, 11.2))})
             for backend_name in comb:
                 row[backend_name] = ppv((backend_name, OFF))
             self.assertTrue(compiler_filter_typechecked(row, self.version_relation), f"{row}")
@@ -1010,7 +1009,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         ]:
             reason_msg = io.StringIO()
 
-            row: ParameterValueTuple = OD({DEVICE_COMPILER: ppv((NVCC, 11.2))})
+            row = BashiRow({DEVICE_COMPILER: ppv((NVCC, 11.2))})
             for backend_name, value in comb:
                 row[backend_name] = ppv((backend_name, value))
             self.assertFalse(
@@ -1022,7 +1021,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             compiler_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 11.3)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),
@@ -1038,7 +1037,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 12.2)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -1053,7 +1052,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         HOST_COMPILER: ppv((GCC, 9)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -1070,7 +1069,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         for compiler_name in set(COMPILERS) - set([NVCC, CLANG_CUDA]):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -1083,7 +1082,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
@@ -1096,7 +1095,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((compiler_name, 9999)),
                             DEVICE_COMPILER: ppv((compiler_name, 9999)),
@@ -1110,7 +1109,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             CMAKE: ppv((CMAKE, 3.18)),
                             HOST_COMPILER: ppv((compiler_name, 9999)),
@@ -1133,7 +1132,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         ):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((host_compiler[0], host_compiler[1])),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((cuda_sdk[0], cuda_sdk[1])),
@@ -1152,7 +1151,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((host_compiler[0], host_compiler[1])),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((cuda_sdk[0], cuda_sdk[1])),
@@ -1172,7 +1171,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         for version in (10.1, 11.2, 12.3):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, version)),
@@ -1186,7 +1185,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((NVCC, version_nvcc)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1206,7 +1205,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         for gcc_version, version_cuda in ((5, 10.2), (9, 11.8), (11, 12.2)):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, gcc_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1221,7 +1220,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, gcc_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1239,7 +1238,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((GCC, gcc_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1262,7 +1261,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
                 reason_msg1 = io.StringIO()
                 self.assertFalse(
                     backend_filter_typechecked(
-                        OD(
+                        BashiRow(
                             {
                                 HOST_COMPILER: ppv((CLANG, clang_version)),
                                 ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1284,7 +1283,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         for clang_version, version_cuda in ((5, 10.2), (9, 11.8), (11, 12.2)):
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG, clang_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1299,7 +1298,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
             self.assertTrue(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG, clang_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1317,7 +1316,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             HOST_COMPILER: ppv((CLANG, clang_version)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv(
@@ -1338,7 +1337,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
     def test_unsupported_cuda_device_compiler_b13(self):
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((NVCC, 11.2)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -1350,7 +1349,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         DEVICE_COMPILER: ppv((CLANG_CUDA, 15)),
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -1364,7 +1363,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
             reason_msg1 = io.StringIO()
             self.assertFalse(
                 backend_filter_typechecked(
-                    OD(
+                    BashiRow(
                         {
                             DEVICE_COMPILER: ppv((device_compiler, 7)),
                             ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.2)),
@@ -1383,7 +1382,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
     def test_cuda_and_hip_backend_cannot_be_active_at_the_same_time_b14(self):
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -1395,7 +1394,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.4)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -1407,7 +1406,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -1420,7 +1419,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.7)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -1436,7 +1435,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, OFF)),
@@ -1451,7 +1450,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_GPU_HIP_ENABLE: ppv((ALPAKA_ACC_GPU_HIP_ENABLE, ON)),
@@ -1470,7 +1469,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
     def test_cuda_and_sycl_backend_cannot_be_active_at_the_same_time_b15(self):
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
@@ -1482,7 +1481,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.4)),
                         ALPAKA_ACC_ONEAPI_CPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF)),
@@ -1494,7 +1493,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, OFF)),
                         ALPAKA_ACC_ONEAPI_FPGA_ENABLE: ppv((ALPAKA_ACC_ONEAPI_FPGA_ENABLE, ON)),
@@ -1507,7 +1506,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg1 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         ALPAKA_ACC_GPU_CUDA_ENABLE: ppv((ALPAKA_ACC_GPU_CUDA_ENABLE, 11.7)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),
@@ -1523,7 +1522,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
 
         self.assertTrue(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF)),
@@ -1538,7 +1537,7 @@ class TestNvccCompilerFilter(unittest.TestCase):
         reason_msg2 = io.StringIO()
         self.assertFalse(
             backend_filter_typechecked(
-                OD(
+                BashiRow(
                     {
                         CMAKE: ppv((CMAKE, 3.18)),
                         ALPAKA_ACC_ONEAPI_GPU_ENABLE: ppv((ALPAKA_ACC_ONEAPI_GPU_ENABLE, ON)),


### PR DESCRIPTION
BashiRow works like an parameter-value-tuple with one exception. If an parameter is accessed, which is not in the parameter-value-tuple a dummy object is return instead throwing an error. The dummy object can be used to compare the value-name or value-version. The comparision will return `False` every time. Therefore the following expression in a filter rule can be compressed: `HOST_COMPILER in row and row[HOST_COMPILER].name == NVCC` -> `row[HOST_COMPILER].name == NVCC`